### PR TITLE
Customer-clarity and readability polish

### DIFF
--- a/autonomous-actions/index.html
+++ b/autonomous-actions/index.html
@@ -25,14 +25,14 @@
         radial-gradient(1200px 700px at 50% -10%, #16202c 0%, var(--bg) 60%),
         var(--bg);
       color: var(--ink);
-      font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      font: 15px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
       -webkit-font-smoothing: antialiased;
     }
     header {
       padding: 14px 22px 6px;
     }
     header h1 { margin: 0; font-size: 17px; letter-spacing: 0.2px; font-weight: 650; }
-    header p { margin: 2px 0 0; color: var(--ink-dim); font-size: 12.5px; }
+    header p { margin: 2px 0 0; color: var(--ink-dim); font-size: 13.5px; }
     /* Left column stacks the diagram and its caption; the controls panel is a
        separate full-height right column, so its sliders never push the caption
        down (the caption stays under the diagram, at diagram width). */
@@ -53,21 +53,21 @@
       backdrop-filter: blur(6px);
     }
     /* Little's Law: a collapsible section in the controls panel (built by controls.js). */
-    .little-law { margin: 6px 0 0; font-size: 11px; color: var(--ink-dim); line-height: 1.45; }
-    #little-body { margin-top: 7px; font-variant-numeric: tabular-nums; font-size: 12px; }
+    .little-law { margin: 6px 0 0; font-size: 12px; color: var(--ink-dim); line-height: 1.45; }
+    #little-body { margin-top: 7px; font-variant-numeric: tabular-nums; font-size: 13px; }
     #little-body .eq { color: var(--ink); }
     #little-body .eq b { color: var(--ink); font-weight: 700; }
     #little-body .have { margin-top: 3px; color: var(--ink-dim); }
     #little-body.over .have, #little-body.over .have b { color: var(--amber); }
-    #slo { display: flex; align-items: center; gap: 8px; padding: 2px 4px 6px; font-size: 12px; color: var(--ink-dim); }
-    #slo b { padding: 2px 9px; border-radius: 999px; font-size: 11px; font-weight: 700; letter-spacing: 0.4px; }
+    #slo { display: flex; align-items: center; gap: 8px; padding: 2px 4px 6px; font-size: 13px; color: var(--ink-dim); }
+    #slo b { padding: 2px 9px; border-radius: 999px; font-size: 12px; font-weight: 700; letter-spacing: 0.4px; }
     #slo b.met { background: rgba(47,214,184,0.18); color: var(--teal); }
     #slo b.breached { background: rgba(255,90,114,0.18); color: var(--red); }
     .info { position: relative; cursor: help; color: var(--ink-dim); }
     .info .tip {
       display: none; position: absolute; bottom: 150%; left: 50%; transform: translateX(-50%);
       width: 230px; background: var(--panel-solid); border: 1px solid var(--border); border-radius: 8px;
-      padding: 8px 10px; font-size: 11px; font-weight: 400; color: var(--ink); line-height: 1.45; z-index: 20;
+      padding: 8px 10px; font-size: 12.5px; font-weight: 400; color: var(--ink); line-height: 1.45; z-index: 20;
     }
     .info:hover .tip, .info:focus .tip { display: block; }
     #metrics { display: flex; flex-wrap: wrap; gap: 8px; padding: 4px 4px 10px; }
@@ -76,7 +76,7 @@
       border: 1px solid var(--border);
       border-radius: 999px;
       padding: 4px 11px;
-      font-size: 12px;
+      font-size: 13px;
       color: var(--ink-dim);
     }
     .chip b { color: var(--ink); font-weight: 650; font-variant-numeric: tabular-nums; }
@@ -102,12 +102,12 @@
     .panelhead h2 { margin: 0; }
     .panelhead .reset { font-size: 11px; padding: 3px 9px; }
     .control { display: block; margin: 0 0 11px; }
-    .control .lab { display: flex; justify-content: space-between; font-size: 12px; color: var(--ink-dim); margin-bottom: 3px; }
+    .control .lab { display: flex; justify-content: space-between; font-size: 13px; color: var(--ink-dim); margin-bottom: 3px; }
     .control .lab b { color: var(--ink); font-variant-numeric: tabular-nums; }
     input[type=range] {
       width: 100%; accent-color: var(--teal); background: transparent; cursor: pointer;
     }
-    .control.toggle { display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: var(--ink-dim); }
+    .control.toggle { display: flex; justify-content: space-between; align-items: center; font-size: 13px; color: var(--ink-dim); }
     .control.toggle input { accent-color: var(--teal); width: auto; cursor: pointer; }
     .ctlrow { display: flex; gap: 10px; }
     .ctlrow .control { flex: 1; min-width: 0; }
@@ -115,7 +115,7 @@
     details.section { margin: 6px 0 0; padding-top: 6px; border-top: 1px solid var(--border); }
     details.section > summary {
       cursor: pointer; user-select: none; list-style: none; display: flex; align-items: center; gap: 8px;
-      padding: 4px 0; font-size: 10.5px; text-transform: uppercase; letter-spacing: 1px; color: var(--ink-dim); font-weight: 700;
+      padding: 4px 0; font-size: 11.5px; text-transform: uppercase; letter-spacing: 1px; color: var(--ink-dim); font-weight: 700;
     }
     details.section > summary::-webkit-details-marker { display: none; }
     details.section > summary::before { content: '\25B8'; font-size: 13px; color: var(--ink-dim); transition: transform .15s ease; }
@@ -126,12 +126,12 @@
 
     /* Tour bar */
     .tourhead { display: flex; align-items: center; gap: 12px; }
-    .acttitle { font-size: 15px; font-weight: 650; flex: 1; }
+    .acttitle { font-size: 16px; font-weight: 650; flex: 1; }
     #act-instruction { margin: 10px 0 0; color: var(--teal); font-weight: 600; max-width: 78ch; }
     #act-caption { margin: 6px 0 0; color: var(--ink); max-width: 78ch; }
     button {
       background: #1b2531; color: var(--ink); border: 1px solid var(--border);
-      border-radius: 9px; padding: 7px 13px; font: inherit; font-size: 13px; cursor: pointer;
+      border-radius: 9px; padding: 7px 13px; font: inherit; font-size: 14px; cursor: pointer;
       transition: background .15s, border-color .15s;
     }
     button:hover { background: #223042; border-color: #35485c; }
@@ -142,7 +142,7 @@
     .dot { width: 8px; height: 8px; border-radius: 50%; background: #29384a; }
     .dot.on { background: var(--teal); box-shadow: 0 0 8px var(--teal); }
     #readout {
-      margin-top: 10px; font-size: 12.5px; color: var(--amber);
+      margin-top: 10px; font-size: 13.5px; color: var(--amber);
       font-variant-numeric: tabular-nums; min-height: 1em;
     }
 
@@ -154,11 +154,11 @@
     .card.dep { stroke-width: 2; }
     .card.dep.faulted { stroke: var(--red) !important; stroke-width: 3.5; filter: drop-shadow(0 0 10px var(--red)); }
     .card.dep.slow { stroke: var(--amber) !important; stroke-width: 3; filter: drop-shadow(0 0 9px var(--amber)); }
-    .nodelabel { fill: var(--ink); font-size: 14px; font-weight: 600; }
-    .nodesub { fill: var(--ink-dim); font-size: 11px; }
-    .glyph { fill: var(--ink-dim); font-size: 11px; }
-    .region { fill: var(--ink-dim); font-size: 9.5px; text-transform: uppercase; letter-spacing: 1px; }
-    .outlabel { fill: var(--ink-dim); font-size: 10px; font-weight: 700; }
+    .nodelabel { fill: var(--ink); font-size: 15px; font-weight: 600; }
+    .nodesub { fill: var(--ink-dim); font-size: 12.5px; }
+    .glyph { fill: var(--ink-dim); font-size: 12.5px; }
+    .region { fill: var(--ink-dim); font-size: 11px; text-transform: uppercase; letter-spacing: 1px; }
+    .outlabel { fill: var(--ink-dim); font-size: 11.5px; font-weight: 700; }
     .fire { font-size: 17px; }
 
     .edge { stroke: #1e2a37; stroke-width: 3; fill: none; }
@@ -185,7 +185,7 @@
        wrapper is actively cutting calls to that dependency. */
     .stopwatch circle, .stopwatch line { stroke: var(--ink-dim); fill: none; transition: stroke .2s ease; }
     .stopwatch.cut circle, .stopwatch.cut line { stroke: var(--amber); }
-    .stopwatchlabel { fill: var(--ink-dim); font-size: 9.5px; font-variant-numeric: tabular-nums; transition: fill .2s ease; }
+    .stopwatchlabel { fill: var(--ink-dim); font-size: 11px; font-variant-numeric: tabular-nums; transition: fill .2s ease; }
     .stopwatchlabel.cut { fill: var(--amber); }
 
     input[type=range]:disabled { accent-color: var(--ink-dim); opacity: 0.55; cursor: not-allowed; }
@@ -205,12 +205,12 @@
     .badge.closed { fill: var(--teal); }
     .badge.half_open { fill: var(--amber); }
     .badge.open { fill: var(--red); animation: pulse 1.1s ease-in-out infinite; }
-    .badgelabel { fill: var(--ink-dim); font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .badgelabel { fill: var(--ink-dim); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
     @keyframes pulse { 0%,100% { filter: none; } 50% { filter: drop-shadow(0 0 7px var(--red)); } }
 
     .queuetrack { fill: #16202b; stroke: #223041; stroke-width: 1; }
     .queuebar { fill: var(--amber); opacity: 0.85; transition: height .2s ease, y .2s ease; }
-    .queuecap { fill: var(--ink-dim); font-size: 9px; letter-spacing: 0.3px; }
+    .queuecap { fill: var(--ink-dim); font-size: 10.5px; letter-spacing: 0.3px; }
   </style>
 </head>
 <body>

--- a/autonomous-actions/index.html
+++ b/autonomous-actions/index.html
@@ -135,6 +135,9 @@
       transition: background .15s, border-color .15s;
     }
     button:hover { background: #223042; border-color: #35485c; }
+    /* Tour navigation stands out in the accent color. */
+    #back, #next { background: var(--teal); color: #06231d; border-color: transparent; font-weight: 650; }
+    #back:hover, #next:hover { background: #4be3c6; border-color: transparent; }
     .progress { display: flex; gap: 6px; margin-left: auto; }
     .dot { width: 8px; height: 8px; border-radius: 50%; background: #29384a; }
     .dot.on { background: var(--teal); box-shadow: 0 0 8px var(--teal); }

--- a/autonomous-actions/index.html
+++ b/autonomous-actions/index.html
@@ -210,6 +210,7 @@
 
     .queuetrack { fill: #16202b; stroke: #223041; stroke-width: 1; }
     .queuebar { fill: var(--amber); opacity: 0.85; transition: height .2s ease, y .2s ease; }
+    .queuecap { fill: var(--ink-dim); font-size: 9px; letter-spacing: 0.3px; }
   </style>
 </head>
 <body>

--- a/autonomous-actions/index.html
+++ b/autonomous-actions/index.html
@@ -11,7 +11,7 @@
       --panel-solid: #141b24;
       --border: #24303d;
       --ink: #dce5f0;
-      --ink-dim: #8397ab;
+      --ink-dim: #aebccb;
       --teal: #2fd6b8;
       --red: #ff5a72;
       --amber: #ffb64d;
@@ -139,7 +139,8 @@
     #back, #next { background: var(--teal); color: #06231d; border-color: transparent; font-weight: 650; }
     #back:hover, #next:hover { background: #4be3c6; border-color: transparent; }
     .progress { display: flex; gap: 6px; margin-left: auto; }
-    .dot { width: 8px; height: 8px; border-radius: 50%; background: #29384a; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; background: #29384a; cursor: pointer; }
+    .dot:hover { background: var(--ink-dim); }
     .dot.on { background: var(--teal); box-shadow: 0 0 8px var(--teal); }
     #readout {
       margin-top: 10px; font-size: 13.5px; color: var(--amber);
@@ -191,10 +192,10 @@
     input[type=range]:disabled { accent-color: var(--ink-dim); opacity: 0.55; cursor: not-allowed; }
 
     /* "Fork me on GitHub" corner ribbon (pure CSS, no external asset). */
-    .forkribbon { position: fixed; top: 0; right: 0; width: 150px; height: 150px; overflow: hidden; z-index: 50; pointer-events: none; }
+    .forkribbon { position: fixed; bottom: 0; right: 0; width: 150px; height: 150px; overflow: hidden; z-index: 50; pointer-events: none; }
     .forkribbon a {
-      position: absolute; top: 34px; right: -42px; width: 200px; padding: 6px 0;
-      transform: rotate(45deg); text-align: center; pointer-events: auto; text-decoration: none;
+      position: absolute; bottom: 34px; right: -42px; width: 200px; padding: 6px 0;
+      transform: rotate(-45deg); text-align: center; pointer-events: auto; text-decoration: none;
       background: var(--teal); color: #06231d; font-size: 12px; font-weight: 700; letter-spacing: 0.3px;
       box-shadow: 0 2px 8px rgba(0,0,0,0.4);
       border-top: 1px solid rgba(255,255,255,0.4); border-bottom: 1px solid rgba(0,0,0,0.3);

--- a/autonomous-actions/src/config.js
+++ b/autonomous-actions/src/config.js
@@ -27,9 +27,9 @@ export function defaultConfig() {
     // internal ids; label/note are what the player sees.
     targets: {
       'Database A': target(30, '#5aa2ff', 'DB', 'Database', ''),
-      'Service B': target(50, '#2fd6b8', 'Rep', 'Reports Service', 'Slow, higher timeout'),
-      'Service C': target(50, '#ff5a72', 'An', 'Analytics Service', 'Fast, lower timeout'),
-      'External': target(120, '#ffb64d', 'Ext', 'External Service', 'Random outages'),
+      'Service B': target(50, '#2fd6b8', 'Rep', 'Reports Service', ''),
+      'Service C': target(50, '#ff5a72', 'An', 'Analytics Service', ''),
+      'External': target(120, '#ffb64d', 'Ext', 'External Service', ''),
     },
     // phaseRef shifts the sine's zero crossing so it can resume from wherever the
     // player releases the rate slider instead of snapping back to the old phase.

--- a/autonomous-actions/src/controls.js
+++ b/autonomous-actions/src/controls.js
@@ -211,7 +211,7 @@ function buildControls(actIndex) {
     oscillationToggle(sys);
     littleSection(true);
     for (const name of Object.keys(sim.config.targets)) {
-      const sec = section(labelOf(name), false);
+      const sec = section(labelOf(name), false, sim.config.targets[name].color);
       latencySlider(sec, name);
       outgoingTimeoutSlider(sec, name);
       errorRateSlider(sec, name);
@@ -233,20 +233,20 @@ function buildControls(actIndex) {
   littleSection(actIndex >= 4);                    // required-workers readout, opens at the saturation act
   // Service sections, focus service on top so its knobs stay at eye level.
   if (actIndex >= 4) {                             // Reports (the slow one): focus from its incident on
-    const sec = section(labelOf('Service B'), actIndex === 4);
+    const sec = section(labelOf('Service B'), actIndex === 4, sim.config.targets['Service B'].color);
     latencySlider(sec, 'Service B');
     outgoingTimeoutSlider(sec, 'Service B');
     breakerRow(sec, 'Service B');
     if (actIndex >= 5) bulkheadSlider(sec, 'Service B');
   }
   if (actIndex >= 3) {                             // Analytics (the fast one): focus of the timeout act
-    const sec = section(labelOf('Service C'), actIndex === 3);
+    const sec = section(labelOf('Service C'), actIndex === 3, sim.config.targets['Service C'].color);
     latencySlider(sec, 'Service C');
     outgoingTimeoutSlider(sec, 'Service C');
     breakerRow(sec, 'Service C');
   }
   if (actIndex >= 1) {                             // External: its errors, and (once breakers exist) its breaker
-    const sec = section(labelOf('External'), actIndex === 1);
+    const sec = section(labelOf('External'), actIndex === 1, sim.config.targets['External'].color);
     errorRateSlider(sec, 'External');
     if (actIndex >= 2) breakerRow(sec, 'External');
   }
@@ -256,10 +256,14 @@ function buildControls(actIndex) {
 // plays the slide-and-flash reveal on the act a section first appears, so a
 // newly unlocked block is obvious. Sections start open; the player can collapse
 // any of them, which matters most in free play where every section shows at once.
-function section(label, entering) {
+function section(label, entering, color) {
   const sec = document.createElement('details');
   sec.className = entering ? 'section enter' : 'section';
   sec.open = true;
+  // A color stripe ties the panel section to its service on the diagram. Kept as a
+  // border (a UI element, not text) so it does not put low-contrast colored text on
+  // the dark panel; the label stays high-contrast.
+  if (color) { sec.style.borderLeft = `3px solid ${color}`; sec.style.paddingLeft = '8px'; }
   const sum = document.createElement('summary');
   sum.textContent = label;
   sec.appendChild(sum);
@@ -283,9 +287,11 @@ function littleSection(open) {
 
 // Act progress dots
 const progress = document.getElementById('progress');
-const dots = ACTS.map(() => {
+const dots = ACTS.map((_, k) => {
   const d = document.createElement('span');
   d.className = 'dot';
+  d.title = `Go to act ${k + 1}`;
+  d.addEventListener('click', () => goToActNumber(k + 1));
   progress.appendChild(d);
   return d;
 });

--- a/autonomous-actions/src/controls.js
+++ b/autonomous-actions/src/controls.js
@@ -270,7 +270,7 @@ function section(label, entering) {
 // Little's Law as its own collapsible section: the required-workers readout,
 // updated live by updateLittle. Opens at the saturation act; collapsible anytime.
 function littleSection(open) {
-  const sec = section("Little's Law", false);
+  const sec = section("Little's Law (safe to ignore)", false);
   sec.open = open;
   const law = document.createElement('p');
   law.className = 'little-law';

--- a/autonomous-actions/src/render.js
+++ b/autonomous-actions/src/render.js
@@ -116,6 +116,7 @@ export function initRender(root, config) {
   root.appendChild(queueBar);
   const queueLabel = el('text', { class: 'outlabel', x: 428, y: GW.y + 70, 'text-anchor': 'middle' }, '');
   root.appendChild(queueLabel);
+  root.appendChild(el('text', { class: 'queuecap', x: 428, y: GW.y + 288, 'text-anchor': 'middle' }, 'queue'));
 
   // Dependencies
   names.forEach((name, i) => {
@@ -150,6 +151,8 @@ export function initRender(root, config) {
     root.appendChild(depQueueBar);
     const depQueueLabel = el('text', { class: 'outlabel', x: NODE_X - 12, y: y - 3, 'text-anchor': 'middle' }, '');
     root.appendChild(depQueueLabel);
+    const qcx = NODE_X - 22, qcy = y + NODE_H / 2;   // vertical "queue" caption left of the bar
+    root.appendChild(el('text', { class: 'queuecap', x: qcx, y: qcy, 'text-anchor': 'middle', transform: `rotate(-90 ${qcx} ${qcy})` }, 'queue'));
     Object.assign(deps[name], { card, badge, badgeLabel, fire, capSlots, capLabel, depQueueBar, depQueueLabel, depQueueBottom: y + NODE_H });
   });
 

--- a/autonomous-actions/src/scenarios.js
+++ b/autonomous-actions/src/scenarios.js
@@ -9,19 +9,19 @@ export const ACTS = [
     caption: 'Every request calls all dependencies at once and holds a worker until the slowest one replies, so throughput is the pool divided by that hold time.',
     readoutVisible: false },
 
-  { title: 'Incident: External refuses connections',
-    instruction: 'Set its error rate to 100% and watch availability fall, since every request calls it. What is the maximum error rate we can handle and still meet our SLO?',
+  { title: 'Incident: the External Service refuses connections',
+    instruction: 'The External Service is a third-party dependency we do not control, like a payment gateway or a maps API. Set its error rate to 100% and watch availability fall, since every request calls it. What is the maximum error rate we can handle and still meet our SLO?',
     caption: 'Fast failures return instantly, so they never tie up a worker. But with nothing to catch them, they pass straight to the client and the SLO breaks.',
     readoutVisible: false },
 
   { title: 'Response: circuit breaker',
-    instruction: 'Turn the External error rate up to 5% and confirm the SLO breaches. Then ship a breaker: turn breakers on with a threshold around 5 errors per second, and watch it trip. The failing calls become degraded responses instead of errors, so availability recovers.',
+    instruction: 'Turn the External Service error rate up to 5% and confirm the SLO breaches. Then add a circuit breaker: turn breakers on with a threshold around 5 errors per second, and watch it trip. The failing calls become degraded responses instead of errors, so availability recovers.',
     caption: 'A breaker short-circuits calls to a dependency we already know is down, so we stop paying for them. Availability recovers, but only if that feature can be switched off: the feature that needed the External Service is now down for 100% of people, instead of the whole service being down for some of them. It is a difficult call.',
     readoutVisible: false },
 
   { title: 'Incident: Analytics hangs',
-    instruction: 'Analytics is supposed to be fast, so a tight timeout on it is cheap. Set its outgoing timeout to about 200 ms and notice healthy traffic is untouched. Then make it hang: drag its latency up to several seconds. The timeout cuts the hung calls at 200 ms, they count as errors, and the breaker you already shipped trips and turns them into degraded responses.',
-    caption: 'A timeout limits the damage one runaway call can do: it caps how long we will wait, so a single hung request cannot tie up a worker indefinitely. On a dependency that is meant to be fast, a tight timeout is cheap insurance: set just above normal latency, it almost never fires in health, but it cuts a hang short, and the breaker then catches the errors it produces.',
+    instruction: 'Analytics is supposed to be fast, so a tight timeout on it is cheap. Set its outgoing timeout to about 200 ms and notice healthy traffic is untouched. Then make it stall: drag its latency up to several seconds. The timeout cuts those stalled calls off at 200 ms, they count as errors, and the breaker you added earlier trips and turns them into degraded responses.',
+    caption: 'A timeout limits the damage from a call that never comes back: it caps how long we will wait, so one stuck call cannot tie up a worker forever. On a dependency that is meant to be fast, a tight timeout is cheap insurance: set just above normal latency, it almost never fires while things are healthy, but it cuts a stuck call off fast, and the breaker then catches the errors it produces.',
     readoutVisible: false },
 
   { title: 'Incident: Reports slows down',


### PR DESCRIPTION
Polish from live customer walkthroughs. No behavior change; copy, labels, and sizing only.

- Named and glossed the External Service (a third-party dependency), and replaced dev jargon ("ship a breaker" became "add a circuit breaker"; "runaway call" became "a call that never comes back").
- Labeled Little's Law "(safe to ignore)" so it reads as optional.
- Labeled the queue bars, so an empty track still reads as a queue rather than an unlabeled sliver.
- Colored the Back/Next tour buttons in the accent color.
- Bumped text sizes for readability, weighted toward the SVG diagram labels, which render below their nominal px because the diagram scales down to fit its column.

- [ ] I, the human author, have fully read and comprehended this code. Until this is checked, please don't waste time reviewing.

Starting points:
- [autonomous-actions/src/scenarios.js:13](https://github.com/vosechu/vosechu.github.io/pull/3/files#diff-b0efaedf4c6718c1a624353cd87a3c8c58c079addb1afc7f4ad0d0a98767c485R13): the External Service gloss (Acts 2 through 4 are reworded)
- [autonomous-actions/index.html:139](https://github.com/vosechu/vosechu.github.io/pull/3/files#diff-c71dde965ca15a0a66712811a4a420d332e64e5063b8a5a9484e3c4e358c1607R139): the green Back/Next styling; the font-size bumps and queue caption are elsewhere in this same file

## Test plan
- [x] `npm test`: 43 pass (engine + scenarios)
- [x] `node --check` on the changed JS, clean
- [ ] Rendered copy, sizes, labels, and button color on the deployed page: not verified (needs the branch built)
