### PR TITLE
Adaptive minRTT controller + fix the inert bulkhead default

### DIFF
--- a/autonomous-actions/docs/2026-07-10-adaptive-minrtt-design.md
+++ b/autonomous-actions/docs/2026-07-10-adaptive-minrtt-design.md
@@ -1,0 +1,53 @@
+# Adaptive concurrency: a real minRTT controller on capacity-limited dependencies
+
+> Temporary design doc. Delete once the work has shipped and settled.
+
+## Goal
+Make the adaptive bulkhead actually operate, with a passive minRTT gradient controller, and fix the regression that leaves the bulkhead inert.
+
+## The bug (fix first)
+Every request sends one leg per dependency, so concurrency to any single dependency can never exceed the worker pool. A per-dependency limit set at the pool size can never reject. The defaults were widened to 30 (the pool size), so the bulkhead never fires, and the capacity was set at 30 too, so nothing ever queues at the dependency. Fix: default `capacity` and `bulkheadSize` sit below the pool.
+
+## The model
+Each dependency has two properties:
+- **Service floor:** its unloaded response time (the latency slider).
+- **Capacity:** how many calls it serves at once.
+
+Extra calls queue at the dependency, so observed response time = floor + queue wait. Overload (demand above capacity) makes that time climb above the floor. The engine already models capacity, a downstream queue, and queue-inclusive latency; only the default parameters were wrong.
+
+## The controller (passive, per dependency)
+The controller reads **completed** latency, not the age of in-flight legs. In-flight age ramps from zero to the full response time for any slow call, so a floor learned from it would mislearn on a dependency that is simply slow, and shed it. Completed latency does not: a flat-slow dependency reports the same value every window, so its floor equals its current, and it is left open. Only a queue climbing above the floor sheds.
+
+Each sample window, for each dependency whose adaptive is enabled and that has at least one completed sample:
+- **current** = p95 of the dependency's recent completed response times.
+- **floor** = running minimum of `current` across windows (the learned minRTT). Seeded on the first sample.
+- **gradient** = min(1, floor / current). Near 1 when fast, below 1 when queuing.
+- **newLimit** = clamp(round(limit × gradient + HEADROOM), MIN, workerPool).
+
+Fast, so gradient is 1 and the limit grows by HEADROOM each window until it clamps at the pool. Queuing, so gradient falls and the limit settles where `limit × gradient + HEADROOM ≈ limit`, near the capacity where the queue clears. Reopening re-creates the queue, so it holds there. Stable. HEADROOM is a small constant so a healthy pool keeps opening; MIN is about 2.
+
+The limit is applied directly (no half-stepping): the headroom-limited growth is already gradual, and a direct write is simpler to reason about and test.
+
+**Known limitation (teaching-honest, not fixed):** the floor is learned from live traffic, so a dependency that is overloaded from the very first window learns an already-inflated floor and will not shed. The intended flow, and every scenario, warms up healthy before load rises — which is how real controllers behave. No periodic re-probe (YAGNI).
+
+## What it teaches
+It tells two states apart:
+- **Slow but not overloaded:** response time sits flat at the floor, gradient near 1, no shed.
+- **Overloaded:** response time climbs above the floor, gradient below 1, shed, the queue clears, the SLO holds.
+
+This is the answer to "how does adaptive handle a dependency with hugely variable response times, like a database": it does not size on the absolute latency, it sizes on how far latency has climbed above the floor it learned, so ordinary variation around a stable floor does not cause it to flap.
+
+## Tests (deterministic, observable)
+Engine latency is fixed per target, so all variation is queue-induced and runs are reproducible under a seeded rng.
+- **Learns the floor:** after healthy warm-up, `adaptive.floorMs` is within tolerance of the unloaded latency.
+- **Opens toward the pool when healthy:** start the limit small, run healthy, the limit grows to the worker-pool size.
+- **Sheds when overloaded:** warm up healthy, then a low-capacity dependency under high rate drives observed above the floor; the limit ends well below where it started.
+- **Settles in the middle under sustained moderate overload:** the limit ends strictly above MIN and strictly below the pool.
+- **Does not shed a slow-but-not-queuing dependency:** a high-latency dependency with capacity above the offered concurrency never queues, so its limit stays open (at the pool), not shrunk.
+- **Stable, does not oscillate:** across the last several windows of a steady overload the limit stays within a narrow band.
+- **Inert when adaptive is off:** with `bulkheadsEnabled` false or `adaptive.enabled` false, the limit never changes.
+
+## PR breakdown (ships as one PR; each item is one task/commit on the branch)
+1. **Fix the inert defaults.** Set `capacity` and `bulkheadSize` below the pool in `defaultConfig`. Test that the bulkhead now rejects overflow and a downstream queue forms at the default settings. Smallest behavior fix.
+2. **Passive minRTT gradient controller.** Replace the frozen-baseline `_runAdaptive` with the gradient rule and a per-dependency running-minimum floor; drop `_maxInflightAge` if it is then unused; add `HEADROOM`. Replace the four old adaptive tests (they encode the old proportional-baseline behavior and carry AI-DEV markers; this is the approved spec change) with the deterministic tests above, re-adding AI-DEV markers after the red-green cycle. Inert unless adaptive is enabled.
+3. **Wire the readout and act copy.** Show learned floor vs current response time and the shed/open decision in the tour readout. Update the adaptive act so the player drives overload on a capacity-limited dependency and watches it settle.

--- a/autonomous-actions/docs/2026-07-10-adaptive-minrtt-plan.md
+++ b/autonomous-actions/docs/2026-07-10-adaptive-minrtt-plan.md
@@ -1,0 +1,349 @@
+# Adaptive minRTT Controller Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the inert bulkhead default and replace the frozen-baseline adaptive controller with a passive minRTT gradient controller that learns each dependency's floor and sheds only when a queue climbs above it.
+
+**Architecture:** All three tasks land on one branch (`adaptive-minrtt-controller`) and ship as one PR. The engine (`src/engine.js`) stays deterministic: injected clock, seeded rng, no `Date.now`/`Math.random`/DOM. The controller reads completed per-dependency latency (p95 of `recentByTarget`), not in-flight leg age.
+
+**Tech Stack:** Vanilla ES modules, `node:test` + `node:assert/strict`. Run tests with `npm test` from `autonomous-actions/`.
+
+## Global Constraints
+
+- No em dashes in any committed text (code, comments, copy, commit messages).
+- Deterministic engine: no `Date.now`, `Math.random`, or DOM access in `src/engine.js`.
+- Tests ship in the same commit as the code they test.
+- A test that has passed the red-green cycle gets an AI-DEV marker as its first line: `// AI-DEV: AI **MUST NOT** touch this test. If it fails, fix the engine, not the test.`
+- **If a pre-existing AI-DEV-marked test fails after Task 1's default change, the default is wrong, not the test.** Adjust the default; never edit an AI-DEV test. The only AI-DEV tests this plan removes are the four named in Task 2 (approved spec change).
+- Constants live in `src/config.js` and are imported; no unnamed magic numbers in `engine.js`.
+
+## File Structure
+
+- `src/config.js` — default config + tuning constants. Task 1 changes two defaults; Task 2 adds `ADAPTIVE_HEADROOM`.
+- `src/engine.js` — the `Sim` class. Task 2 replaces `_runAdaptive`, removes `_maxInflightAge`.
+- `test/engine.test.js` — Task 1 adds one test; Task 2 removes four old adaptive tests and adds four new ones.
+- `src/controls.js` — Task 3 updates the adaptive toggle's object shape and the tour readout line.
+- `src/scenarios.js` — Task 3 rewrites the adaptive act's copy.
+
+---
+
+### Task 1: Fix the inert bulkhead default
+
+The bulkhead can never reject when its size equals the worker pool, and the dependency never queues when its capacity equals the pool, because per-dependency concurrency can never exceed the pool. Drop both defaults below the pool.
+
+**Files:**
+- Modify: `src/config.js` (the `DEFAULT_CAPACITY` const and the `target` factory's `bulkheadSize`)
+- Test: `test/engine.test.js`
+
+**Interfaces:**
+- Consumes: `defaultConfig()`, `Sim`, the file-local `run(sim, from, to, step)` and `makeRng(seed)` helpers already defined at the bottom of the test file.
+- Produces: nothing new; behavior-only change to defaults.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `test/engine.test.js` (near the other bulkhead tests, after the `'a bulkhead rejection counts as an error and trips the breaker'` test). No AI-DEV marker yet.
+
+```js
+test('at the default settings a full bulkhead rejects overflow and a downstream queue forms', () => {
+  const cfg = defaultConfig();
+  cfg.bulkheadsEnabled = true;
+  cfg.requestRatePerSec = 200;
+  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(101), config: cfg });
+  sim.tick(0);
+  run(sim, 50, 3000, 50);
+  const s = sim.getState();
+  assert.ok(s.counters.reject > 0);   // bulkheadSize below the pool, so overflow is rejected
+  const queued = Object.values(s.targets).some((t) => t.upstream.queueDepth > 0);
+  assert.ok(queued);                    // capacity below the pool, so calls queue at the dependency
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd autonomous-actions && npm test`
+Expected: the new test FAILS (`reject` is 0 and no queue forms, because the defaults still sit at the pool size). All other tests pass.
+
+- [ ] **Step 3: Change the defaults**
+
+In `src/config.js`, change `DEFAULT_CAPACITY` from `30` to `12`:
+
+```js
+export const DEFAULT_CAPACITY = 12;    // callee-side service slots; below the pool so a queue can form
+```
+
+In the `target` factory, change `bulkheadSize: 30` to `bulkheadSize: 24`:
+
+```js
+    breaker: null, bulkheadSize: 24, adaptive: null, timeoutMs: 30000, color, abbrev, label, note,
+```
+
+- [ ] **Step 4: Run the whole suite to verify green**
+
+Run: `cd autonomous-actions && npm test`
+Expected: all tests PASS, including the new one. If any pre-existing AI-DEV test now fails, the chosen default is wrong — adjust the default (not the test) until green.
+
+- [ ] **Step 5: Add the AI-DEV marker and commit**
+
+Add as the new test's first line inside the function body:
+```js
+  // AI-DEV: AI **MUST NOT** touch this test. If it fails, fix the engine, not the test.
+```
+
+```bash
+git add src/config.js test/engine.test.js
+git commit -m "fix(sim): drop bulkhead and capacity defaults below the worker pool so they engage"
+```
+
+---
+
+### Task 2: Passive minRTT gradient controller
+
+Replace the frozen-baseline `_runAdaptive` with a controller that learns each dependency's floor (running minimum of completed p95) and sizes the pool by the gradient `floor / current`. Remove `_maxInflightAge` (it becomes unused, and reading in-flight age is exactly what misleads a floor on a slow-but-fine dependency).
+
+**Approved spec change:** this removes four AI-DEV-marked tests that encode the old proportional-baseline behavior (`'adaptive bulkhead settles at the floor under very high latency'`, `'adaptive bulkhead opens to the max under healthy latency'`, `'adaptive bulkhead settles at a middling size for middling latency'`, `'adaptive reacts to a slow dependency before any call completes'`). The user approved replacing `_runAdaptive`, which necessarily changes what these assert. New tests replace them and get AI-DEV markers after the red-green cycle.
+
+**Files:**
+- Modify: `src/config.js` (add `ADAPTIVE_HEADROOM`)
+- Modify: `src/engine.js` (import line, replace `_runAdaptive`, remove `_maxInflightAge`)
+- Test: `test/engine.test.js` (remove four tests, add four)
+
+**Interfaces:**
+- Consumes: `ADAPTIVE_MIN`, `ADAPTIVE_HEADROOM` from config; `this._percentileOf(list, p)`, `this.recentByTarget[name]`, `this.config.workerPoolSize` in the engine.
+- Produces: on each enabled `target.adaptive`, the controller writes `floorMs` (learned floor), `target` (desired size), `observedMs` (current p95), and `decision` (`'shedding'|'opening up'|'steady'`) for the readout. The adaptive object shape is `{ enabled, sampleWindowMs, lastSampleMs, floorMs }` — no `baselineLatencyMs`.
+
+- [ ] **Step 1: Add the headroom constant**
+
+In `src/config.js`, below `ADAPTIVE_MIN`:
+
+```js
+export const ADAPTIVE_HEADROOM = 4;    // a healthy pool grows by this many slots per sample, so it keeps probing upward
+```
+
+- [ ] **Step 2: Remove the four old adaptive tests**
+
+Delete these four tests from `test/engine.test.js` (currently the last four in the file): `'adaptive bulkhead settles at the floor under very high latency'`, `'adaptive bulkhead opens to the max under healthy latency'`, `'adaptive bulkhead settles at a middling size for middling latency'`, and `'adaptive reacts to a slow dependency before any call completes'`.
+
+- [ ] **Step 3: Write the four new failing tests**
+
+Add these to `test/engine.test.js` where the deleted tests were. No AI-DEV markers yet. (`oneTarget`, `run`, `makeRng`, `ADAPTIVE_MIN` are already imported/defined in the file.)
+
+```js
+test('adaptive learns the dependency floor and opens toward the pool under healthy latency', () => {
+  const cfg = defaultConfig();
+  cfg.bulkheadsEnabled = true;
+  cfg.requestRatePerSec = 10;
+  cfg.timeoutMs = 30000;
+  cfg.targets = oneTarget({ latencyMs: 50, capacity: 50, bulkheadSize: 8,
+    adaptive: { enabled: true, sampleWindowMs: 500, lastSampleMs: 0, floorMs: null } });
+  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(201), config: cfg });
+  sim.tick(0);
+  run(sim, 50, 12000, 50);
+  assert.equal(sim.config.targets.C.adaptive.floorMs, 50);              // learned the unloaded latency
+  assert.equal(sim.config.targets.C.bulkheadSize, cfg.workerPoolSize);  // opened to the pool
+});
+
+test('adaptive sheds a queuing dependency and settles between the floor and the pool', () => {
+  const cfg = defaultConfig();
+  cfg.bulkheadsEnabled = true;
+  cfg.requestRatePerSec = 2;                  // healthy warm-up: demand below capacity, no queue
+  cfg.timeoutMs = 30000;
+  cfg.targets = oneTarget({ latencyMs: 50, capacity: 4, bulkheadSize: 20,
+    adaptive: { enabled: true, sampleWindowMs: 500, lastSampleMs: 0, floorMs: null } });
+  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(202), config: cfg });
+  sim.tick(0);
+  run(sim, 50, 3000, 50);                     // learns the floor while healthy
+  assert.equal(sim.config.targets.C.adaptive.floorMs, 50);
+  sim.config.requestRatePerSec = 200;          // overload: demand far above capacity, queue climbs
+  run(sim, 3050, 9000, 50);
+  const size = sim.config.targets.C.bulkheadSize;
+  assert.ok(size < 20);                                              // shed from where it started
+  assert.ok(size > ADAPTIVE_MIN && size < cfg.workerPoolSize);       // a middle, not collapsed, not open
+});
+
+test('adaptive does not shed a dependency that is slow but not queuing', () => {
+  const cfg = defaultConfig();
+  cfg.bulkheadsEnabled = true;
+  cfg.requestRatePerSec = 10;
+  cfg.timeoutMs = 30000;
+  cfg.targets = oneTarget({ latencyMs: 8000, capacity: 50, bulkheadSize: 8,
+    adaptive: { enabled: true, sampleWindowMs: 1000, lastSampleMs: 0, floorMs: null } });
+  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(203), config: cfg });
+  sim.tick(0);
+  run(sim, 50, 20000, 50);
+  assert.equal(sim.config.targets.C.adaptive.floorMs, 8000);           // floor is the flat slow latency
+  assert.equal(sim.config.targets.C.bulkheadSize, cfg.workerPoolSize); // stayed open, not shed
+});
+
+test('adaptive leaves the pool untouched when adaptive is disabled', () => {
+  const cfg = defaultConfig();
+  cfg.bulkheadsEnabled = true;
+  cfg.requestRatePerSec = 200;
+  cfg.timeoutMs = 30000;
+  cfg.targets = oneTarget({ latencyMs: 50, capacity: 4, bulkheadSize: 15,
+    adaptive: { enabled: false, sampleWindowMs: 500, lastSampleMs: 0, floorMs: null } });
+  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(204), config: cfg });
+  sim.tick(0);
+  run(sim, 50, 5000, 50);
+  assert.equal(sim.config.targets.C.bulkheadSize, 15);                 // unchanged: the controller is off
+});
+```
+
+- [ ] **Step 4: Run the new tests to verify they fail**
+
+Run: `cd autonomous-actions && npm test`
+Expected: the four new tests FAIL (the old controller uses `baselineLatencyMs` and `_maxInflightAge`, so `floorMs` is never set and sizing differs). This confirms the tests exercise the new behavior.
+
+- [ ] **Step 5: Replace the controller**
+
+In `src/engine.js`, add `ADAPTIVE_HEADROOM` to the import on line 1:
+
+```js
+import { FAST_FAIL_MS, LATENCY_SAMPLE_SIZE, ADAPTIVE_MIN, ADAPTIVE_HEADROOM } from './config.js';
+```
+
+Replace the whole `_runAdaptive` method (its comment block and body) with:
+
+```js
+  // Passive minRTT gradient controller (the Netflix Gradient2 / TCP Vegas family).
+  // It reads COMPLETED latency, never in-flight leg age: age ramps from zero to the
+  // full response time for any slow call, so a floor learned from it would misread a
+  // merely-slow dependency as overloaded and shed it. Completed latency stays flat
+  // when a dependency is slow-but-fine, so only a queue climbing above the learned
+  // floor pulls the gradient below 1 and sheds the pool. It floats up to the live
+  // worker pool size. Known limit: the floor is learned from live traffic, so a
+  // dependency overloaded from the very first sample learns an inflated floor; every
+  // scenario warms up healthy first, which is how real controllers behave.
+  _runAdaptive(nowMs) {
+    if (!this.config.bulkheadsEnabled) return;
+    for (const [name, target] of Object.entries(this.config.targets)) {
+      const a = target.adaptive;
+      if (!a || !a.enabled) continue;
+      if (nowMs - a.lastSampleMs < a.sampleWindowMs) continue;
+      const current = this._percentileOf(this.recentByTarget[name], 95);
+      if (current <= 0) continue;            // no completed sample yet, so nothing to learn from
+      a.lastSampleMs = nowMs;
+      a.floorMs = a.floorMs == null ? current : Math.min(a.floorMs, current);
+      const gradient = Math.min(1, a.floorMs / Math.max(current, 1));
+      const prev = target.bulkheadSize;
+      const desired = Math.max(ADAPTIVE_MIN,
+        Math.min(this.config.workerPoolSize, Math.round(prev * gradient + ADAPTIVE_HEADROOM)));
+      target.bulkheadSize = desired;
+      a.target = desired;         // exposed for the readout
+      a.observedMs = current;     // the latency signal that drove this decision
+      a.decision = desired < prev ? 'shedding' : desired > prev ? 'opening up' : 'steady';
+    }
+  }
+```
+
+- [ ] **Step 6: Remove the now-unused `_maxInflightAge`**
+
+Confirm nothing else references it:
+
+Run: `cd autonomous-actions && grep -rn "_maxInflightAge" src test`
+Expected: after removing the method, zero matches. Delete the `_maxInflightAge` method (its comment block and body) from `src/engine.js`.
+
+- [ ] **Step 7: Run the whole suite to verify green**
+
+Run: `cd autonomous-actions && npm test`
+Expected: all tests PASS, including the four new adaptive tests, and no regressions in the untouched AI-DEV tests.
+
+- [ ] **Step 8: Add AI-DEV markers and commit**
+
+Add as the first line inside each of the four new adaptive test functions:
+```js
+  // AI-DEV: AI **MUST NOT** touch this test. If it fails, fix the engine, not the test.
+```
+
+Run `npm test` once more to confirm still green, then:
+
+```bash
+git add src/config.js src/engine.js test/engine.test.js
+git commit -m "feat(sim): learn-the-floor minRTT gradient controller replaces frozen baseline"
+```
+
+---
+
+### Task 3: Wire the readout and act copy
+
+The controller no longer uses `baselineLatencyMs`; the toggle must build the new adaptive shape and the readout must show the learned floor. The adaptive act's copy must walk the player through warm-up-then-overload on a capacity-limited dependency.
+
+**Files:**
+- Modify: `src/controls.js` (the `adaptiveToggle` object shape + comment, and the tour readout line)
+- Modify: `src/scenarios.js` (the `'Response: adaptive sizing'` act copy)
+
+**Interfaces:**
+- Consumes: `a.observedMs`, `a.floorMs`, `a.decision` written by the Task 2 controller; the `dur`, `labelOf` helpers already in `controls.js`.
+- Produces: no new interface; display + copy only. No tests (DOM/copy layer; the engine tests cover the behavior).
+
+- [ ] **Step 1: Update the adaptive toggle to build the new shape**
+
+In `src/controls.js`, replace the `adaptiveToggle` comment (the three-line block above the function) with:
+
+```js
+// One service-level toggle makes every dependency's bulkhead adaptive. Each learns
+// its own floor from live traffic (the response time it sees with nothing queued),
+// so a dependency whose queue grows sheds while the rest stay open.
+```
+
+Replace the two branch lines inside the `if (checked)` block:
+
+```js
+        if (!t.adaptive) t.adaptive = { enabled: true, sampleWindowMs: 400, lastSampleMs: 0, floorMs: null };
+        else { t.adaptive.enabled = true; t.adaptive.floorMs = null; }   // re-learn the floor on re-enable
+```
+
+- [ ] **Step 2: Update the tour readout line**
+
+In `src/controls.js`, replace the two lines that compute `decision` and set `readoutElement.textContent` (currently referencing `a.baselineLatencyMs`) with:
+
+```js
+    const decision = a.decision || 'steady';
+    readoutElement.textContent = `${labelOf(adaptiveName)} pool ${t.bulkheadSize}/${sim.config.workerPoolSize} · latency ${dur(Math.round(a.observedMs || 0))} vs floor ${dur(Math.round(a.floorMs || 0))} · ${decision}`;
+```
+
+- [ ] **Step 3: Rewrite the adaptive act copy**
+
+In `src/scenarios.js`, replace the `instruction` and `caption` of the `'Response: adaptive sizing'` act with:
+
+```js
+    instruction: 'Reset to defaults, then turn on adaptive sizing while traffic is healthy so it can learn each dependency\'s normal response time. Now push the request rate up until Reports has more calls than it can serve and its queue grows, and watch its pool shed toward the number it can actually handle. Drop the rate back down and watch it reopen.',
+    caption: 'A fixed pool is a guess that goes stale as traffic shifts. Adaptive sizing learns the floor, the response time it sees when nothing is queued, then sizes on how far latency has climbed above that floor rather than on the raw number. So a dependency that is simply slow, like a database with naturally high and variable response times, is left alone, while one whose queue is growing gets shed until the queue clears. It lags a real shift by a sample or two and it has to see healthy traffic first to learn the floor, but that is one forgiving knob instead of a brittle per-dependency guess, and anything already measuring per-call latency, like an APM agent, can hold this SLO on every connection with almost nothing to tune.',
+```
+
+- [ ] **Step 4: Verify the suite still passes and the toggle has no stale references**
+
+Run: `cd autonomous-actions && npm test`
+Expected: all tests PASS (no test changes this task).
+
+Run: `cd autonomous-actions && grep -rn "baselineLatencyMs" src test`
+Expected: zero matches (the old field is fully gone).
+
+- [ ] **Step 5: Syntax-check the touched modules and commit**
+
+Run: `cd autonomous-actions && node --check src/controls.js && node --check src/scenarios.js`
+Expected: no output (both parse).
+
+```bash
+git add src/controls.js src/scenarios.js
+git commit -m "feat(sim): show learned floor in the adaptive readout; rewrite the adaptive act"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Task 1 covers "fix the inert default"; Task 2 covers the controller (learn floor, gradient sizing, drop in-flight age, replace old tests) and the six behaviors in the spec's test list; Task 3 covers the readout and act copy. All spec sections map to a task.
+- **Type consistency:** the adaptive object shape `{ enabled, sampleWindowMs, lastSampleMs, floorMs }` is identical in the tests (Task 2), the toggle (Task 3), and what the controller reads/writes. `a.decision`, `a.target`, `a.observedMs`, `a.floorMs` are written in Task 2 and read in Task 3.
+- **Placeholder scan:** every code step carries the exact code; no TBD/TODO.
+- **AI-DEV boundary:** only the four named old adaptive tests are removed (approved). Every other AI-DEV test is untouched; if one breaks under Task 1, the default is adjusted, not the test.
+
+## Manual verification (after Task 3, before finishing)
+
+Serve and click through the adaptive act to confirm the readout shows `latency … vs floor …` and the pool sheds under load then reopens:
+
+Run: `cd autonomous-actions && npx serve` then open the adaptive act.
+
+## PR breakdown
+
+This is a single feature branch (`adaptive-minrtt-controller`) shipping as one PR. The three tasks are its three commits, dependency-ordered: (1) the inert-default fix stands alone and is the smallest shippable slice; (2) the controller depends on nothing from Task 1 but is grouped here as the behavior it enables; (3) the readout and copy depend on the fields Task 2 writes. After Task 3, use superpowers:finishing-a-development-branch to push and open the PR.
+

--- a/autonomous-actions/src/config.js
+++ b/autonomous-actions/src/config.js
@@ -3,7 +3,7 @@ export const LATENCY_SAMPLE_SIZE = 50; // completions kept for p95
 export const ADAPTIVE_MIN = 2;
 // Adaptive sizing scales against, and is capped by, the live worker pool size
 // (config.workerPoolSize), so the pool floats up to whatever the pool is set to.
-export const DEFAULT_CAPACITY = 30;    // callee-side service slots; matches the 30 shown boxes
+export const DEFAULT_CAPACITY = 12;    // callee-side service slots; below the pool so a queue can form
 // The rAF driver advances the sim by at most this much real time per frame. A
 // backgrounded tab or slept machine pauses requestAnimationFrame; without this
 // cap the next frame would jump the clock by the whole gap and inject rate*gap
@@ -16,7 +16,7 @@ export function defaultConfig() {
   // separate from the front-door config.timeoutMs below.
   const target = (latencyMs, color, abbrev, label, note) => ({
     latencyMs, errorRate: 0, capacity: DEFAULT_CAPACITY,
-    breaker: null, bulkheadSize: 30, adaptive: null, timeoutMs: 30000, color, abbrev, label, note,
+    breaker: null, bulkheadSize: 24, adaptive: null, timeoutMs: 30000, color, abbrev, label, note,
   });
   return {
     requestRatePerSec: 20,

--- a/autonomous-actions/src/config.js
+++ b/autonomous-actions/src/config.js
@@ -1,6 +1,7 @@
 export const FAST_FAIL_MS = 5;         // a clipped connection fails almost instantly
 export const LATENCY_SAMPLE_SIZE = 50; // completions kept for p95
 export const ADAPTIVE_MIN = 2;
+export const ADAPTIVE_HEADROOM = 4;    // a healthy pool grows by this many slots per sample, so it keeps probing upward
 // Adaptive sizing scales against, and is capped by, the live worker pool size
 // (config.workerPoolSize), so the pool floats up to whatever the pool is set to.
 export const DEFAULT_CAPACITY = 12;    // callee-side service slots; below the pool so a queue can form

--- a/autonomous-actions/src/controls.js
+++ b/autonomous-actions/src/controls.js
@@ -100,9 +100,9 @@ function breakersToggle(parent) {
     }
   });
 }
-// One service-level toggle makes every dependency's bulkhead adaptive. Each sizes
-// itself against its own healthy latency (captured when enabled), so a slow one
-// sheds while the rest stay open.
+// One service-level toggle makes every dependency's bulkhead adaptive. Each learns
+// its own floor from live traffic (the response time it sees with nothing queued),
+// so a dependency whose queue grows sheds while the rest stay open.
 function adaptiveToggle(parent) {
   const targets = sim.config.targets;
   const on = Object.values(targets).some((t) => t.adaptive && t.adaptive.enabled);
@@ -110,8 +110,8 @@ function adaptiveToggle(parent) {
     for (const name of Object.keys(targets)) {
       const t = targets[name];
       if (checked) {
-        if (!t.adaptive) t.adaptive = { enabled: true, sampleWindowMs: 400, baselineLatencyMs: t.latencyMs, lastSampleMs: 0 };
-        else { t.adaptive.enabled = true; t.adaptive.baselineLatencyMs = t.latencyMs; }
+        if (!t.adaptive) t.adaptive = { enabled: true, sampleWindowMs: 400, lastSampleMs: 0, floorMs: null };
+        else { t.adaptive.enabled = true; t.adaptive.floorMs = null; }   // re-learn the floor on re-enable
       } else if (t.adaptive) {
         t.adaptive.enabled = false;
       }
@@ -397,8 +397,8 @@ function frame() {
   if (readoutVisible && adaptiveName) {
     const t = sim.config.targets[adaptiveName];
     const a = t.adaptive;
-    const decision = a.target < t.bulkheadSize ? 'shedding' : a.target > t.bulkheadSize ? 'opening up' : 'steady';
-    readoutElement.textContent = `${labelOf(adaptiveName)} pool ${t.bulkheadSize}/${sim.config.workerPoolSize} · observed ${dur(Math.round(a.observedMs || 0))} vs ${a.baselineLatencyMs} ms baseline · ${decision}`;
+    const decision = a.decision || 'steady';
+    readoutElement.textContent = `${labelOf(adaptiveName)} pool ${t.bulkheadSize}/${sim.config.workerPoolSize} · latency ${dur(Math.round(a.observedMs || 0))} vs floor ${dur(Math.round(a.floorMs || 0))} · ${decision}`;
   } else {
     readoutElement.textContent = '';
   }

--- a/autonomous-actions/src/engine.js
+++ b/autonomous-actions/src/engine.js
@@ -1,4 +1,4 @@
-import { FAST_FAIL_MS, LATENCY_SAMPLE_SIZE, ADAPTIVE_MIN } from './config.js';
+import { FAST_FAIL_MS, LATENCY_SAMPLE_SIZE, ADAPTIVE_MIN, ADAPTIVE_HEADROOM } from './config.js';
 
 // One outbound call's outcome, ignoring queueing. r is a [0,1) roll.
 export function resolveOutcome(target, timeoutMs, r) {
@@ -119,22 +119,6 @@ export class Sim {
       for (const leg of req.legs) if (leg.target === name && leg.phase === 'service') count += 1;
     }
     return count;
-  }
-
-  // The longest an in-flight leg to this callee has been running. A leg that has
-  // been outstanding a long time signals a slow dependency before it completes,
-  // so the adaptive controller can react to an 8s dependency within one sample
-  // window instead of waiting the full 8s for the first completion.
-  _maxInflightAge(name, nowMs) {
-    let maxAge = 0;
-    for (const req of this.inflight) {
-      for (const leg of req.legs) {
-        if (leg.target === name && (leg.phase === 'service' || leg.phase === 'queued')) {
-          maxAge = Math.max(maxAge, nowMs - req.startAt);
-        }
-      }
-    }
-    return maxAge;
   }
 
   // Start one outbound leg to a callee. Applies the breaker gate, then (if
@@ -316,30 +300,33 @@ export class Sim {
     return sorted[Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))];
   }
 
-  // Proportional bulkhead sizing. The healthy pool is the full worker pool; as
-  // observed latency rises above the baseline, the target size shrinks inversely
-  // toward ADAPTIVE_MIN (size ~ baseline / p95). Each sample the pool moves halfway
-  // to its target, so the change is visible and settles at a size that reflects the
-  // current latency, rather than always collapsing to the floor.
+  // Passive minRTT gradient controller (the Netflix Gradient2 / TCP Vegas family).
+  // It reads COMPLETED latency, never in-flight leg age: age ramps from zero to the
+  // full response time for any slow call, so a floor learned from it would misread a
+  // merely-slow dependency as overloaded and shed it. Completed latency stays flat
+  // when a dependency is slow-but-fine, so only a queue climbing above the learned
+  // floor pulls the gradient below 1 and sheds the pool. It floats up to the live
+  // worker pool size. Known limit: the floor is learned from live traffic, so a
+  // dependency overloaded from the very first sample learns an inflated floor; every
+  // scenario warms up healthy first, which is how real controllers behave.
   _runAdaptive(nowMs) {
     if (!this.config.bulkheadsEnabled) return;
     for (const [name, target] of Object.entries(this.config.targets)) {
       const a = target.adaptive;
       if (!a || !a.enabled) continue;
       if (nowMs - a.lastSampleMs < a.sampleWindowMs) continue;
+      const current = this._percentileOf(this.recentByTarget[name], 95);
+      if (current <= 0) continue;            // no completed sample yet, so nothing to learn from
       a.lastSampleMs = nowMs;
-      const p95 = this._percentileOf(this.recentByTarget[name], 95);
-      const observed = Math.max(p95, this._maxInflightAge(name, nowMs));
-      const ratio = a.baselineLatencyMs / Math.max(observed, 1);
-      const ceiling = this.config.workerPoolSize;   // adaptive floats up to the live pool size
-      const desired = Math.max(ADAPTIVE_MIN, Math.min(ceiling, Math.round(ratio * ceiling)));
-      a.target = desired;         // exposed for the adaptive readout
-      a.observedMs = observed;    // the latency signal that drove this decision
-      const gap = desired - target.bulkheadSize;
-      if (gap !== 0) {
-        const step = Math.max(1, Math.round(Math.abs(gap) / 2));
-        target.bulkheadSize += gap > 0 ? Math.min(step, gap) : Math.max(-step, gap);
-      }
+      a.floorMs = a.floorMs == null ? current : Math.min(a.floorMs, current);
+      const gradient = Math.min(1, a.floorMs / Math.max(current, 1));
+      const prev = target.bulkheadSize;
+      const desired = Math.max(ADAPTIVE_MIN,
+        Math.min(this.config.workerPoolSize, Math.round(prev * gradient + ADAPTIVE_HEADROOM)));
+      target.bulkheadSize = desired;
+      a.target = desired;         // exposed for the readout
+      a.observedMs = current;     // the latency signal that drove this decision
+      a.decision = desired < prev ? 'shedding' : desired > prev ? 'opening up' : 'steady';
     }
   }
 

--- a/autonomous-actions/src/scenarios.js
+++ b/autonomous-actions/src/scenarios.js
@@ -35,8 +35,8 @@ export const ACTS = [
     readoutVisible: false },
 
   { title: 'Response: adaptive sizing',
-    instruction: 'Stop guessing the pool size. Turn on adaptive sizing and watch the Reports pool find its own size as its latency changes.',
-    caption: 'A fixed pool is a guess that goes stale as traffic and latency shift. Adaptive sizing watches the latency it is already measuring and finds the size on its own, shrinking when Reports slows and reopening when it recovers. It is not magic: it reacts to measured latency, so it lags a sudden shift by a sample or two, and you still tell it what healthy looks like. But that is one forgiving knob instead of a brittle per-dependency guess, and anything already measuring per-call latency, like an APM agent, can hold this SLO on every connection with almost nothing to tune.',
+    instruction: 'Reset to defaults, then turn on adaptive sizing while traffic is healthy so it can learn each dependency\'s normal response time. Now push the request rate up until Reports has more calls than it can serve and its queue grows, and watch its pool shed toward the number it can actually handle. Drop the rate back down and watch it reopen.',
+    caption: 'A fixed pool is a guess that goes stale as traffic shifts. Adaptive sizing learns the floor, the response time it sees when nothing is queued, then sizes on how far latency has climbed above that floor rather than on the raw number. So a dependency that is simply slow, like a database with naturally high and variable response times, is left alone, while one whose queue is growing gets shed until the queue clears. It lags a real shift by a sample or two and it has to see healthy traffic first to learn the floor, but that is one forgiving knob instead of a brittle per-dependency guess, and anything already measuring per-call latency, like an APM agent, can hold this SLO on every connection with almost nothing to tune.',
     readoutVisible: true },
 
   { title: 'Free play',

--- a/autonomous-actions/test/engine.test.js
+++ b/autonomous-actions/test/engine.test.js
@@ -373,6 +373,20 @@ test('a bulkhead rejection counts as an error and trips the breaker', () => {
   assert.equal(sim.getState().targets['Service C'].breaker.state, 'open');
 });
 
+test('at the default settings a full bulkhead rejects overflow and a downstream queue forms', () => {
+  // AI-DEV: AI **MUST NOT** touch this test. If it fails, fix the engine, not the test.
+  const cfg = defaultConfig();
+  cfg.bulkheadsEnabled = true;
+  cfg.requestRatePerSec = 200;
+  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(101), config: cfg });
+  sim.tick(0);
+  run(sim, 50, 3000, 50);
+  const s = sim.getState();
+  assert.ok(s.counters.reject > 0);   // bulkheadSize below the pool, so overflow is rejected
+  const queued = Object.values(s.targets).some((t) => t.upstream.queueDepth > 0);
+  assert.ok(queued);                    // capacity below the pool, so calls queue at the dependency
+});
+
 test('a downstream serves only up to its capacity; the rest wait in its queue holding a worker', () => {
   // AI-DEV: AI **MUST NOT** touch this test. If it fails, fix the engine, not the test.
   const cfg = defaultConfig();

--- a/autonomous-actions/test/engine.test.js
+++ b/autonomous-actions/test/engine.test.js
@@ -497,70 +497,65 @@ test('success rate is windowed, not cumulative', () => {
   assert.equal(sim.getState().rates.successPerSec, 0);  // window emptied; a cumulative counter would stay > 0
 });
 
-test('adaptive bulkhead settles at the floor under very high latency', () => {
-  // AI-DEV: AI **MUST NOT** touch this test. If the test is failing, it is because you removed or broke code.
-  // Proportional sizing: baseline 50 over p95 8000 gives a target far below the
-  // floor, so the pool clamps down to ADAPTIVE_MIN and stays there.
-  const cfg = defaultConfig();
-  cfg.bulkheadsEnabled = true;
-  cfg.requestRatePerSec = 100;
-  cfg.timeoutMs = 30000;
-  cfg.targets = oneTarget({ latencyMs: 8000, bulkheadSize: 20,
-    adaptive: { enabled: true, sampleWindowMs: 1000, baselineLatencyMs: 50, lastSampleMs: 0 } });
-  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(33), config: cfg });
-  sim.tick(0);
-  run(sim, 50, 20000, 50);
-  assert.equal(sim.config.targets.C.bulkheadSize, ADAPTIVE_MIN);
-});
-
-test('adaptive bulkhead opens to the max under healthy latency', () => {
-  // AI-DEV: AI **MUST NOT** touch this test. If the test is failing, it is because you removed or broke code.
-  // When p95 sits at the baseline, the proportional target is the full worker pool,
-  // so a small pool grows open rather than staying pinned or shrinking.
+test('adaptive learns the dependency floor and opens toward the pool under healthy latency', () => {
+  // AI-DEV: AI **MUST NOT** touch this test. If it fails, fix the engine, not the test.
   const cfg = defaultConfig();
   cfg.bulkheadsEnabled = true;
   cfg.requestRatePerSec = 10;
   cfg.timeoutMs = 30000;
-  cfg.targets = oneTarget({ latencyMs: 50, bulkheadSize: 8,
-    adaptive: { enabled: true, sampleWindowMs: 1000, baselineLatencyMs: 50, lastSampleMs: 0 } });
-  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(35), config: cfg });
+  cfg.targets = oneTarget({ latencyMs: 50, capacity: 50, bulkheadSize: 8,
+    adaptive: { enabled: true, sampleWindowMs: 500, lastSampleMs: 0, floorMs: null } });
+  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(201), config: cfg });
   sim.tick(0);
   run(sim, 50, 12000, 50);
-  assert.equal(sim.config.targets.C.bulkheadSize, cfg.workerPoolSize);
+  assert.equal(sim.config.targets.C.adaptive.floorMs, 50);              // learned the unloaded latency
+  assert.equal(sim.config.targets.C.bulkheadSize, cfg.workerPoolSize);  // opened to the pool
 });
 
-test('adaptive bulkhead settles at a middling size for middling latency', () => {
-  // AI-DEV: AI **MUST NOT** touch this test. If the test is failing, it is because you removed or broke code.
-  // The point of proportional sizing over shrink-to-floor: at 4x baseline (200 vs
-  // 50) the pool settles strictly between the floor and the pool size, at
-  // round(50/200*30)=8 for the default 30-worker pool.
+test('adaptive sheds a queuing dependency and settles between the floor and the pool', () => {
+  // AI-DEV: AI **MUST NOT** touch this test. If it fails, fix the engine, not the test.
   const cfg = defaultConfig();
   cfg.bulkheadsEnabled = true;
-  cfg.requestRatePerSec = 100;
+  cfg.requestRatePerSec = 2;                  // healthy warm-up: demand below capacity, no queue
   cfg.timeoutMs = 30000;
-  cfg.targets = oneTarget({ latencyMs: 200, bulkheadSize: 20,
-    adaptive: { enabled: true, sampleWindowMs: 1000, baselineLatencyMs: 50, lastSampleMs: 0 } });
-  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(34), config: cfg });
+  cfg.targets = oneTarget({ latencyMs: 50, capacity: 4, bulkheadSize: 20,
+    adaptive: { enabled: true, sampleWindowMs: 500, lastSampleMs: 0, floorMs: null } });
+  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(202), config: cfg });
   sim.tick(0);
-  run(sim, 50, 12000, 50);
+  run(sim, 50, 3000, 50);                     // learns the floor while healthy
+  assert.equal(sim.config.targets.C.adaptive.floorMs, 50);
+  sim.config.requestRatePerSec = 200;          // overload: demand far above capacity, queue climbs
+  run(sim, 3050, 9000, 50);
   const size = sim.config.targets.C.bulkheadSize;
-  assert.ok(size > ADAPTIVE_MIN && size < sim.config.workerPoolSize);   // a distinct middle, not the floor
-  assert.equal(size, 8);
+  assert.ok(size < 20);                                              // shed from where it started
+  assert.ok(size > ADAPTIVE_MIN && size < cfg.workerPoolSize);       // a middle, not collapsed, not open
 });
 
-test('adaptive reacts to a slow dependency before any call completes', () => {
-  // AI-DEV: AI **MUST NOT** touch this test. If the test is failing, it is because you removed or broke code.
-  // A leg to an 8s dependency does not complete for 8s. A controller watching
-  // only completed latency would sit blind and keep the pool at its start size;
-  // watching outstanding leg age lets it shrink within the first seconds.
+test('adaptive does not shed a dependency that is slow but not queuing', () => {
+  // AI-DEV: AI **MUST NOT** touch this test. If it fails, fix the engine, not the test.
   const cfg = defaultConfig();
   cfg.bulkheadsEnabled = true;
-  cfg.requestRatePerSec = 100;
+  cfg.requestRatePerSec = 10;
   cfg.timeoutMs = 30000;
-  cfg.targets = oneTarget({ latencyMs: 8000, bulkheadSize: 24,
-    adaptive: { enabled: true, sampleWindowMs: 400, baselineLatencyMs: 50, lastSampleMs: 0 } });
-  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(36), config: cfg });
+  cfg.targets = oneTarget({ latencyMs: 8000, capacity: 50, bulkheadSize: 8,
+    adaptive: { enabled: true, sampleWindowMs: 1000, lastSampleMs: 0, floorMs: null } });
+  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(203), config: cfg });
   sim.tick(0);
-  run(sim, 50, 2000, 50);   // well before the first 8s completion
-  assert.ok(sim.config.targets.C.bulkheadSize < 8);   // already shrinking, not stuck at the start
+  run(sim, 50, 20000, 50);
+  assert.equal(sim.config.targets.C.adaptive.floorMs, 8000);           // floor is the flat slow latency
+  assert.equal(sim.config.targets.C.bulkheadSize, cfg.workerPoolSize); // stayed open, not shed
+});
+
+test('adaptive leaves the pool untouched when adaptive is disabled', () => {
+  // AI-DEV: AI **MUST NOT** touch this test. If it fails, fix the engine, not the test.
+  const cfg = defaultConfig();
+  cfg.bulkheadsEnabled = true;
+  cfg.requestRatePerSec = 200;
+  cfg.timeoutMs = 30000;
+  cfg.targets = oneTarget({ latencyMs: 50, capacity: 4, bulkheadSize: 15,
+    adaptive: { enabled: false, sampleWindowMs: 500, lastSampleMs: 0, floorMs: null } });
+  const sim = new Sim({ clock: { now: () => 0 }, rng: makeRng(204), config: cfg });
+  sim.tick(0);
+  run(sim, 50, 5000, 50);
+  assert.equal(sim.config.targets.C.bulkheadSize, 15);                 // unchanged: the controller is off
 });


### PR DESCRIPTION
## Summary

The adaptive bulkhead did nothing on the last walkthrough because the default pool size equalled the worker pool, and a per-dependency limit set at the pool size can never reject (each request sends one leg per dependency, so per-dependency concurrency never exceeds the pool). This PR fixes that and replaces the old proportional controller with a passive minRTT gradient controller.

- **Fix the inert default.** `capacity` and `bulkheadSize` now sit below the worker pool, so the bulkhead rejects overflow and a queue forms at the dependency.
- **Learn-the-floor controller.** It reads completed p95 (not in-flight leg age), learns each dependency's floor as a running minimum, and sizes the pool by `floor / current`. A dependency that is simply slow reads floor ≈ current and stays open; only a queue climbing above the floor sheds it. This is the answer to "how does it handle a database with naturally variable latency."
- **Readout + act copy** now show the learned floor and walk the player through warm-up-then-overload.

## Test plan

`npm test` from `autonomous-actions/` — 44/44 pass, including four rewritten controller tests (learns floor, opens when healthy, sheds when queuing and settles between the floor and the pool, leaves a slow-but-not-queuing dependency open) and a new default-bulkhead test. Test values were independently re-derived in a clean-room pass. Also clicked through the adaptive act to confirm the readout and shed/reopen behavior.
