### PR TITLE
Pulse the named control when hovering a copy chip

### DIFF
--- a/autonomous-actions/index.html
+++ b/autonomous-actions/index.html
@@ -122,6 +122,14 @@
     .control.toggle input { accent-color: var(--teal); width: auto; cursor: pointer; }
     .ctlrow { display: flex; gap: 10px; }
     .ctlrow .control { flex: 1; min-width: 0; }
+    /* Hovering or focusing a {{chip}} in the copy pulses the control it names,
+       so a lost player's eye lands on the exact knob. Its collapsed section is
+       auto-opened in JS; this is just the soft teal "look here" ring. */
+    .control.pulse { border-radius: 7px; animation: controlPulse 0.85s ease-in-out infinite; }
+    @keyframes controlPulse {
+      0%, 100% { box-shadow: 0 0 0 2px rgba(20, 83, 45, 0); }
+      50%      { box-shadow: 0 0 0 2px rgba(20, 83, 45, 0.55); }
+    }
     /* Collapsible control sections (native <details>), separated by a divider, no box. */
     details.section { margin: 6px 0 0; padding-top: 6px; border-top: 1px solid var(--border); }
     details.section > summary {

--- a/autonomous-actions/src/controls.js
+++ b/autonomous-actions/src/controls.js
@@ -21,15 +21,25 @@ const handle = buildScene(document.getElementById('stage'), { targets: DEFAULT_T
 const panel = document.getElementById('panel');
 
 // Render tokenized copy into an element: plain text nodes, {{chips}} as .ctl
-// spans, [[terms]] as focusable .term spans carrying their glossary tip.
+// spans that pulse their matching panel control on hover/focus, [[terms]] as
+// focusable .term spans carrying their glossary tip.
 function renderCopyInto(el, str) {
   el.textContent = '';
   for (const seg of parseCopy(str)) {
     if (seg.type === 'text') { el.appendChild(document.createTextNode(seg.value)); continue; }
     const span = document.createElement('span');
     span.textContent = seg.value;
-    if (seg.type === 'ctl') { span.className = 'ctl'; }
-    else {
+    if (seg.type === 'ctl') {
+      span.className = 'ctl';
+      span.tabIndex = 0;                         // keyboard users get the same pulse via focus
+      const label = seg.value;
+      const on = () => pulsePanelFor(label, true);
+      const off = () => pulsePanelFor(label, false);
+      span.addEventListener('mouseenter', on);
+      span.addEventListener('mouseleave', off);
+      span.addEventListener('focus', on);
+      span.addEventListener('blur', off);
+    } else {
       span.className = 'term';
       span.tabIndex = 0;
       const tip = document.createElement('span');
@@ -38,6 +48,23 @@ function renderCopyInto(el, str) {
       span.appendChild(tip);
     }
     el.appendChild(span);
+  }
+}
+
+// A chip names a control label exactly (test/strings.test.js enforces it).
+// Hovering or focusing the chip draws the eye to that control: pulse it, and
+// since the panel tucks controls into collapsible sections and reveals them per
+// act, open any collapsed section it sits in and scroll it into view so the
+// pulse never points at something hidden. Live lookup each time, because
+// buildControls rebuilds the panel on every act change.
+function pulsePanelFor(label, on) {
+  for (const ctl of panel.querySelectorAll('[data-control]')) {
+    if (ctl.dataset.control !== label) continue;
+    ctl.classList.toggle('pulse', on);
+    if (!on) continue;
+    const collapsed = ctl.closest('details');
+    if (collapsed && !collapsed.open) collapsed.open = true;
+    ctl.scrollIntoView({ block: 'nearest' });
   }
 }
 
@@ -62,6 +89,7 @@ const dur = (v) => (v >= 1000 ? `${(v / 1000).toFixed(v % 1000 === 0 ? 0 : 1)} s
 // Append a labelled row (label + live value + the given input) to a parent.
 function control(parent, label, input, fmt, value) {
   const wrap = document.createElement('label'); wrap.className = 'control';
+  wrap.dataset.control = label;                 // so a {{chip}} naming this label can find and pulse it
   const lab = document.createElement('span'); lab.className = 'lab';
   const nm = document.createElement('span'); nm.textContent = label;
   const val = document.createElement('b'); val.textContent = fmt(value);
@@ -96,6 +124,7 @@ function logSlider(parent, label, min, max, value, fmt, onInput) {
 
 function toggle(parent, label, checked, onChange) {
   const wrap = document.createElement('label'); wrap.className = 'control toggle';
+  wrap.dataset.control = label;                 // so a {{chip}} naming this toggle can find and pulse it
   const nm = document.createElement('span'); nm.textContent = label;
   const input = document.createElement('input'); Object.assign(input, { type: 'checkbox', checked });
   input.addEventListener('change', () => onChange(input.checked));


### PR DESCRIPTION
Hovering or focusing a control `{{chip}}` in the copy now pulses the matching control in the right panel, so a player who cannot find the knob an instruction names gets it pointed out. This is the last mile of the alpha-player fix: the chip text already equals a panel label exactly (a test enforces it); now the chip also physically points at the control.

Each control is tagged with `data-control="<label>"` when built; each chip gets `mouseenter`/`mouseleave` plus `focus`/`blur` handlers (so keyboard users get the same cue), and a live lookup finds the control even though the panel is rebuilt every act. Because the panel tucks controls into collapsible sections and a lost player may have collapsed one, the pulse also opens any collapsed section the control sits in and scrolls it into view, so it never points at something hidden. `[[terms]]` stay glossary-only; they name concepts, not controls.

Note: stacked on #7 (base `act-aware-tour`, which owns the chip rendering). Merge #7 first; GitHub will retarget this to master.

- [ ] I, the human author, have fully read and comprehended this code. Until this is checked, please don't waste time reviewing.

## Start here
- `src/controls.js` - `renderCopyInto` (chip handlers) and the new `pulsePanelFor` (pulse, auto-open section, scroll); `control`/`toggle` gain the `data-control` tag.
- `index.html` - the `.control.pulse` ring and `controlPulse` keyframe.

## Test plan
- [x] `npm test` - 89/89 pass (chip/term invariants unchanged).
- [x] `node --check src/controls.js` - clean.
- [x] Headless Chrome (runtime DOM): controls carry `data-control` (Request rate and the revealed station knobs), chips render as `<span class="ctl" tabindex="0">`, and the `controlPulse` keyframe is served; app loads without error.
- [ ] Manual: hover/focus a chip and confirm the named control pulses; collapse a section, hover its chip, confirm it auto-opens and scrolls into view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKv8sPDdoy5Nfsx5nPdveb
