### PR TITLE
feat(autonomous-actions): spotlight the newly-unlocked control on act change

### DIFF
--- a/autonomous-actions/index.html
+++ b/autonomous-actions/index.html
@@ -272,18 +272,6 @@
 
     input[type=range]:disabled { accent-color: var(--ink-dim); opacity: 0.55; cursor: not-allowed; }
 
-    /* What's-new bubble: positionBubble (controls.js) moves it beside the panel
-       when an act unlocks controls. (The guided tour itself is Driver.js; see
-       vendor/driver.css and the .driver-popover.aa-tour theme below.) The sim
-       keeps running underneath -- no pause, no page dimming. */
-    .tourbubble {
-      position: fixed; width: min(300px, 80vw); background: var(--panel-solid);
-      border: 1px solid var(--border); border-radius: 12px; padding: 14px 16px;
-      box-shadow: 0 8px 24px rgba(43,29,16,0.24); pointer-events: auto;
-    }
-    .tourbubble p { margin: 0 0 12px; color: var(--ink); line-height: 1.5; font-size: 13px; }
-    .tourbubble.hidden { display: none; }
-    #whatsnew { z-index: 85; }
     /* Red notification dot on the Tour button: an act unlocked new controls
        while the tour was skipped. Cleared when the tour is opened. */
     .tour-rerun-btn { position: relative; }
@@ -291,8 +279,6 @@
       content: ''; position: absolute; top: -3px; right: -3px;
       width: 9px; height: 9px; border-radius: 50%; background: var(--red);
     }
-    .tourfoot { display: flex; align-items: center; gap: 8px; }
-    .tourfoot button { font-size: 12px; padding: 5px 10px; }
 
     /* Driver.js tour popover themed to the app palette (its default is a white
        card with blue buttons). Scoped by popoverClass 'aa-tour'. */
@@ -378,13 +364,6 @@
     <div class="barslot" id="bar-rejects">
       <span class="baglabel"><span id="bar-rejects-label"></span><span class="info" tabindex="0"> &#9432;<span class="tip" id="bar-rejects-hover"></span></span></span>
       <span class="bagvalue" id="bar-rejects-value">0</span>
-    </div>
-  </div>
-
-  <div class="tourbubble hidden" id="whatsnew">
-    <p id="whatsnew-text"></p>
-    <div class="tourfoot">
-      <button id="whatsnew-done">Done</button>
     </div>
   </div>
 

--- a/autonomous-actions/src/controls.js
+++ b/autonomous-actions/src/controls.js
@@ -399,23 +399,6 @@ function writeFlag(key, on) {
   } catch { /* ignore: storage may be unavailable (private mode, etc.) */ }
 }
 
-const whatsnewEl = document.getElementById('whatsnew');
-
-// Place a fixed-position bubble adjacent to its anchor, clamped to the
-// viewport. Measures once per call (step open, whats-new open, window resize
-// while open): never on the per-frame path.
-function positionBubble(bubble, anchorEl, prefer) {
-  const a = anchorEl.getBoundingClientRect();
-  const b = bubble.getBoundingClientRect();
-  let left, top;
-  if (prefer === 'above') { left = a.left + a.width / 2 - b.width / 2; top = a.top - b.height - 12; }
-  else if (prefer === 'left') { left = a.left - b.width - 16; top = a.top + 16; }
-  else { left = a.left + a.width / 2 - b.width / 2; top = a.bottom + 12; }
-  left = Math.max(8, Math.min(left, window.innerWidth - b.width - 8));
-  top = Math.max(8, Math.min(top, window.innerHeight - b.height - 8));
-  bubble.style.left = `${left}px`;
-  bubble.style.top = `${top}px`;
-}
 
 function setTourDot(on) {
   for (const btn of document.querySelectorAll('.tour-rerun-btn')) btn.classList.toggle('dot', on);
@@ -468,23 +451,39 @@ for (const btn of document.querySelectorAll('.tour-rerun-btn')) {
   btn.addEventListener('click', startTour);
 }
 
-// Whats-new: on forward entry into an act that unlocks controls, either show
-// the one-line bubble (tour not skipped) or light the Tour button's dot.
-// Once per act per session; Back never re-triggers it.
+// Whats-new: on forward entry into an act that unlocks controls, spotlight the
+// newly-unlocked control with a one-off Driver.js popover (tour not skipped) or
+// light the Tour button's dot. Once per act per session; Back never re-triggers.
 let prevActIndex = -1;
 const whatsNewShown = new Set();
-document.getElementById('whatsnew-done').textContent = STRINGS.tour.buttons.done;
-document.getElementById('whatsnew-done').addEventListener('click', () => whatsnewEl.classList.add('hidden'));
+let whatsNewCopy = '';
+const whatsNew = driver({
+  showButtons: ['close'],
+  popoverClass: 'aa-tour',
+  onPopoverRender: (popover) => renderCopyInto(popover.description, whatsNewCopy),
+});
+
+// The DOM node for an act's first newly-unlocked control, opening its collapsed
+// section so the spotlight lands on something visible. null when the act unlocks
+// nothing pointable (the free-play sentinel), which centers the popover instead.
+function newControlElement(i) {
+  for (const key of NEW_CONTROLS_BY_ACT[i]) {
+    const el = panel.querySelector(`[data-control="${STRINGS.controls[key]}"]`);
+    if (!el) continue;
+    const section = el.closest('details');
+    if (section && !section.open) section.open = true;
+    return el;
+  }
+  return null;
+}
+
 function maybeShowWhatsNew(i) {
-  // A prior act's bubble is stale the moment the act changes; clear it first,
-  // then re-show only on forward entry into an act that unlocks controls.
-  whatsnewEl.classList.add('hidden');
+  whatsNew.destroy();   // clear any prior act's spotlight before deciding
   if (i <= prevActIndex || whatsNewShown.has(i) || !NEW_CONTROLS_BY_ACT[i]) return;
   if (tourSkipped) { setTourDot(true); return; }
   whatsNewShown.add(i);
-  renderCopyInto(document.getElementById('whatsnew-text'), STRINGS.tour.whatsNew[i]);
-  whatsnewEl.classList.remove('hidden');
-  positionBubble(whatsnewEl, panel, 'left');
+  whatsNewCopy = STRINGS.tour.whatsNew[i];
+  whatsNew.highlight({ element: newControlElement(i) || undefined, popover: { description: ' ' } });
 }
 
 // Auto-open on a first-ever visit. On return visits the tour stays closed; the

--- a/autonomous-actions/src/strings.js
+++ b/autonomous-actions/src/strings.js
@@ -42,7 +42,7 @@ export const STRINGS = {
   // line per bubble. {n} and {m} are filled in with the step number and total.
   // welcome is the one place the arm's voice gets a little room to breathe.
   tour: {
-    buttons: { skip: 'Skip', prev: 'Back', next: 'Next', done: 'Done', rerun: 'Tour' },
+    buttons: { prev: 'Back', next: 'Next', done: 'Done', rerun: 'Tour' },
     step: 'Step {n} of {m}',
     welcome: 'This is our service. Each request goes out to every [[dependency]] at once, and I hold a [[slot]] until the slowest one answers. Our [[SLO]] is the promise we are graded on: 99% of requests succeed, and 95% finish within 5s. Two reading tips: words with a dotted underline each have a definition, so hover or tap one; a word boxed like {{Request rate}} names a control in the panel on the right, matched to its label exactly.',
     bubbleBar: 'Down here is our service\'s health: in particular the [[availability]] and [[response time]], as well as other health measurements that might help you diagnose problems. Click on any of the ⓘ icons to learn more about that measurement.',


### PR DESCRIPTION
Migrates the per-act "what's new" nudge (the popup that appears when an act unlocks a new control) from a hand-positioned bubble to a one-off Driver.js `highlight()` that spotlights the control the act just unlocked, opening its collapsed panel section so the target is visible. Deletes the last hand-rolled tour positioning code: `positionBubble`, the `#whatsnew` markup, and the `.tourbubble`/`.tourfoot` CSS. Net -22 lines.

Stacked on #11 (base is `driverjs-tour`), so this diff is only the what's-new change. Review #11 first.

- [ ] I, the human author, have fully read and comprehended this code. Until this is checked, please don't waste time reviewing.

## Starting points

- [autonomous-actions/src/controls.js:480](https://github.com/vosechu/vosechu.github.io/pull/12/files#diff-20781bb248ff28130e27a6ecbc87570b707b0008a4eeb5396cf0c7a2f9cafc05R480) - `maybeShowWhatsNew`: destroy any prior spotlight, apply the forward-only / once-per-act / skip guards, then highlight.
- [autonomous-actions/src/controls.js:469](https://github.com/vosechu/vosechu.github.io/pull/12/files#diff-20781bb248ff28130e27a6ecbc87570b707b0008a4eeb5396cf0c7a2f9cafc05R469) - `newControlElement`: maps a new-control key to its panel node and opens its collapsed section so the spotlight lands on something visible.

## Concerns

- The nudge now uses Driver's overlay, which briefly dims the page, instead of the old non-modal bubble. Intentional per the "spotlight the new control" goal, but it's more assertive; the X dismisses it.
- Act 7 (free play) unlocks no single pointable control, so its popover centers instead of spotlighting. Worth confirming that reads OK.

## Test plan

- [x] `npm test` - 85/85. No test changes: the what's-new logic is DOM glue (the pure `NEW_CONTROLS_BY_ACT` map it reads is already covered).
- [x] `node --check` on `controls.js` - clean.
- [x] Headless browser at act 2: the error-rate slider is spotlighted with the popover arrow pointing at it and the `error rate` chip rendering; the collapsed Payments section auto-expanded.
- [ ] Interactive pass across all unlocking acts (1-7), including free-play centering - not automated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKv8sPDdoy5Nfsx5nPdveb

