### PR TITLE
feat(ei-hex-game): hexagonal tiles, timer, win detection, undo

### DIFF
--- a/ei-hex-game/index.html
+++ b/ei-hex-game/index.html
@@ -13,7 +13,7 @@
     --line: #575757;
     --warm: #9a9a9a;
     --gold: #f2c879;
-    --ease: cubic-bezier(.34, 1.4, .5, 1);
+    --ease: cubic-bezier(.22, 1.4, .36, 1);   /* quick off the mark, slight overshoot */
   }
   * { box-sizing: border-box; }
   body {
@@ -65,7 +65,7 @@
   .tile svg {
     display: block; width: 100%; height: 100%; pointer-events: none;
     transform: rotate(calc(var(--turn) * 60deg));
-    transition: transform .42s var(--ease);
+    transition: transform .26s var(--ease);
     transition-delay: var(--delay, 0ms);
   }
   .cell {
@@ -252,7 +252,7 @@ function setWarm(i, on) {
 function setRipple(i) {
   const group = i === null ? [] : groups[i];
   tiles.forEach((tile, k) => {
-    tile.style.setProperty('--delay', group.indexOf(k) > 0 ? '55ms' : '0ms');
+    tile.style.setProperty('--delay', group.indexOf(k) > 0 ? '38ms' : '0ms');
   });
 }
 

--- a/ei-hex-game/index.html
+++ b/ei-hex-game/index.html
@@ -6,121 +6,394 @@
 <title>Arrow Puzzle</title>
 <style>
   :root {
-    --p: min(14vw, 11vh);   /* distance between adjacent tile centres */
-    --bg: #363636;
-    --ink: #e8e8e8;
-    --dim: #c0c0c0;
-    --line: #5c5c5c;
+    --p: min(12.5vw, 8.8vh);   /* distance between adjacent tile centres */
+    --bg: #2f2f2f;
+    --ink: #ececec;
+    --dim: #a9a9a9;
+    --line: #575757;
+    --warm: #9a9a9a;
+    --gold: #f2c879;
+    --ease: cubic-bezier(.34, 1.4, .5, 1);
   }
   * { box-sizing: border-box; }
   body {
-    margin: 0; min-height: 100vh; padding-bottom: 2rem;
-    background: var(--bg); color: var(--ink);
+    margin: 0; min-height: 100vh; padding: 0 1rem 2rem;
+    background: radial-gradient(ellipse 70% 60% at 50% 34%, #3d3d3d 0%, var(--bg) 62%, #262626 100%);
+    color: var(--ink);
     font-family: Georgia, "Times New Roman", serif; text-align: center;
     -webkit-text-size-adjust: 100%;
   }
-  h1 { font-weight: 400; font-size: clamp(1.6rem, 5vw, 2.4rem); margin: 1.3rem 0 .5rem; }
-  p { max-width: 26em; margin: 0 auto 1.3rem; padding: 0 1rem; color: var(--dim); }
+  h1 { font-weight: 400; font-size: clamp(1.7rem, 5.5vw, 2.5rem); margin: 1.1rem 0 .3rem; }
+  .hint { max-width: 27em; margin: 0 auto .8rem; color: var(--dim); font-size: .95rem; }
 
-  /* The board is a hexagon of hexagons, so its bounding box is 6.2 x 7 pitches. */
-  #board { position: relative; width: calc(6.2 * var(--p)); height: calc(7 * var(--p)); margin: 0 auto; }
+  /* ---- stats ---- */
+  .stats { display: flex; justify-content: center; gap: clamp(1.2rem, 5vw, 3rem); margin: 0 auto .9rem; }
+  .stat { min-width: 5.5em; }
+  .stat dt { font-size: .7rem; letter-spacing: .14em; text-transform: uppercase; color: var(--dim); }
+  .stat dd {
+    margin: .15rem 0 0; font-size: clamp(1rem, 3.6vw, 1.35rem);
+    font-variant-numeric: tabular-nums; font-feature-settings: "tnum";
+  }
+  #best { color: var(--dim); }
 
+  /* ---- board ----
+     37 flat-top hexes tile into one pointy-top hexagon. A hexagon of hexagons is
+     always turned 30 degrees from its own tiles, so tiles flat-topped and board
+     pointy-topped is the only pairing that matches the reference screenshots.
+     Bounding box is 6.36 x 7 pitches. */
+  #board { position: relative; width: calc(6.36 * var(--p)); height: calc(7 * var(--p)); margin: 0 auto; }
+
+  /* A flat-top hex of pitch P measures 2P/sqrt(3) across the points by P across
+     the flats. clip-path trims the button to that hex so neighbouring tiles,
+     whose rectangles overlap at the corners, can't steal each other's clicks. */
   .tile {
+    --turn: 0;
     position: absolute; left: 50%; top: 50%;
-    width: calc(.98 * var(--p)); aspect-ratio: 1;
+    width: calc(1.1547 * var(--p)); height: var(--p);
     transform: translate(-50%, -50%)
                translate(calc(var(--x) * var(--p)), calc(var(--y) * var(--p)));
-    padding: 0; background: none; border: 1px solid var(--line); border-radius: 50%;
+    padding: 0; border: 0; background: none;
+    clip-path: polygon(0% 50%, 25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%);
     cursor: pointer; -webkit-tap-highlight-color: transparent; touch-action: manipulation;
   }
-  .tile:hover { border-color: #909090; }
-  .tile:focus-visible { outline: 2px solid #9fb8d8; outline-offset: 2px; }
 
-  /* Only the arrow turns; the circle is rotationally symmetric anyway. */
+  /* The hex is drawn a touch inside the clip so its stroke survives, which also
+     leaves the hairline seam between tiles that the screenshots have. */
+  /* Only the arrow needs to turn, but a regular hexagon is unchanged by a sixth
+     of a turn, so spinning the whole SVG costs nothing and keeps the markup flat.
+     pointer-events stay off it so the clip-path above is the only hit area. */
   .tile svg {
-    display: block; width: 100%; height: 100%;
+    display: block; width: 100%; height: 100%; pointer-events: none;
     transform: rotate(calc(var(--turn) * 60deg));
-    transition: transform .22s ease-out;
+    transition: transform .42s var(--ease);
+    transition-delay: var(--delay, 0ms);
   }
-  .tile path {
-    fill: none; stroke: var(--ink); stroke-width: 2.6;
+  .cell {
+    fill: transparent; stroke: var(--line); stroke-width: 2.5;
+    transition: fill .18s ease, stroke .18s ease, stroke-width .18s ease;
+  }
+  .tile.warm .cell { fill: rgba(255, 255, 255, .05); stroke: var(--warm); }
+  .tile:active .cell { fill: rgba(255, 255, 255, .11); }
+  .tile:focus-visible { outline: none; }
+  .tile:focus-visible .cell { stroke: #9fb8d8; stroke-width: 6; }
+
+  .arrow {
+    fill: none; stroke: var(--ink); stroke-width: 12;
     stroke-linecap: round; stroke-linejoin: round;
+    transition: stroke .45s ease;
   }
-  @media (prefers-reduced-motion: reduce) { .tile svg { transition: none; } }
+
+  /* Instant repaint for scrambles and resets: no spin from the old state. */
+  #board.no-tween .tile svg { transition: none; }
+
+  /* ---- solved: a glow rippling out from the centre ---- */
+  #board.solved .cell {
+    animation: flare 1.5s ease-out both;
+    animation-delay: calc(var(--dist) * 130ms);
+  }
+  #board.solved .arrow { stroke: var(--gold); transition-delay: calc(var(--dist) * 130ms); }
+  @keyframes flare {
+    35% { fill: rgba(242, 200, 121, .34); stroke: var(--gold); stroke-width: 4; }
+    100% { fill: rgba(242, 200, 121, .1); stroke: rgba(242, 200, 121, .55); stroke-width: 2.5; }
+  }
+
+  .banner {
+    margin: .9rem auto 0; height: 1.6rem; color: var(--gold); font-size: 1.2rem;
+    opacity: 0; transform: translateY(6px); transition: opacity .5s ease .5s, transform .5s ease .5s;
+  }
+  .banner.show { opacity: 1; transform: none; }
+
+  /* ---- controls ---- */
+  .controls { display: flex; justify-content: center; flex-wrap: wrap; gap: .6rem; margin: .7rem auto 0; }
+  .controls button {
+    font-family: inherit; font-size: .95rem; padding: .5rem 1.1rem;
+    color: var(--ink); background: none; border: 1px solid var(--line); border-radius: 3px;
+    cursor: pointer; transition: border-color .18s ease, background-color .18s ease;
+  }
+  .controls button:hover:enabled { border-color: var(--warm); background: rgba(255, 255, 255, .05); }
+  .controls button:disabled { color: #6d6d6d; cursor: default; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .tile svg, .arrow { transition-duration: 1ms; }
+    #board.solved .cell {
+      animation: none; fill: rgba(242, 200, 121, .1); stroke: rgba(242, 200, 121, .55);
+    }
+    .banner { transition: none; }
+  }
 </style>
 </head>
 <body>
 
 <h1>Arrow Puzzle</h1>
-<p>Make all arrows point upward by tapping tiles. Each tap turns the tile and its neighbours.</p>
+<p class="hint">Make all arrows point upward by tapping tiles. Each tap turns the tile and its neighbours a sixth of a turn clockwise.</p>
+
+<dl class="stats">
+  <div class="stat"><dt>Time</dt><dd id="clock">00:00.000</dd></div>
+  <div class="stat"><dt>Best</dt><dd id="best">&ndash;</dd></div>
+  <div class="stat"><dt>Moves</dt><dd id="moves">0</dd></div>
+</dl>
+
 <div id="board"></div>
+<p class="banner" id="banner" role="status">Solved.</p>
+
+<div class="controls">
+  <button type="button" id="undo" disabled>Undo</button>
+  <button type="button" id="reset">Reset to solved</button>
+  <button type="button" id="fresh">New puzzle</button>
+</div>
 
 <script>
 'use strict';
 
-/* ---------------- game logic (knows nothing about the DOM) ---------------- */
+/* ===================== game logic (knows nothing about the DOM) ===================== */
 
-var RADIUS = 3;                                              // 3n^2 - 3n + 1 = 37 tiles at n = 4
-var NEIGHBOURS = [[1, 0], [1, -1], [0, -1], [-1, 0], [-1, 1], [0, 1]];
+const RADIUS = 3;                                    // 3n^2 - 3n + 1 = 37 tiles at side n = 4
+const STEPS = 6;                                     // sixths of a turn
+const NEIGHBOURS = [[1, 0], [1, -1], [0, -1], [-1, 0], [-1, 1], [0, 1]];
 
 // Axial coordinates of every tile in a hexagon of hexagons.
-var cells = [];
-for (var q = -RADIUS; q <= RADIUS; q++) {
-  for (var r = -RADIUS; r <= RADIUS; r++) {
-    if (Math.abs(q + r) <= RADIUS) cells.push({ q: q, r: r });
+const cells = [];
+for (let q = -RADIUS; q <= RADIUS; q++) {
+  for (let r = -RADIUS; r <= RADIUS; r++) {
+    if (Math.abs(q + r) <= RADIUS) cells.push({ q, r });
   }
 }
 
-var indexOf = new Map(cells.map(function (c, i) { return [c.q + ',' + c.r, i]; }));
+const tileAt = new Map(cells.map((c, i) => [c.q + ',' + c.r, i]));
 
-// Tapping a tile turns it plus whichever of its six neighbours exist on the board.
-var groups = cells.map(function (c) {
-  return [[0, 0]].concat(NEIGHBOURS).map(function (d) {
-    return indexOf.get((c.q + d[0]) + ',' + (c.r + d[1]));
-  }).filter(function (i) { return i !== undefined; });
-});
+// Tapping a tile turns it plus whichever of its six neighbours exist. Index 0 is
+// always the tapped tile itself, which the ripple animation relies on.
+const groups = cells.map(c =>
+  [[0, 0]].concat(NEIGHBOURS)
+    .map(d => tileAt.get((c.q + d[0]) + ',' + (c.r + d[1])))
+    .filter(i => i !== undefined));
+
+// Rings out from the centre, for the solved animation.
+const distanceOf = c => (Math.abs(c.q) + Math.abs(c.r) + Math.abs(c.q + c.r)) / 2;
 
 // Cumulative sixth-turns clockwise per tile. Orientation is turns % 6; solved is all 0.
-var turns = cells.map(function () { return 0; });
+// Counting up forever instead of wrapping keeps CSS rotating the short way at the seam.
+const turns = cells.map(() => 0);
+const taps = [];
 
-function tap(i) {
-  groups[i].forEach(function (j) { turns[j]++; });
+const isSolved = () => turns.every(t => t % STEPS === 0);
+
+function turn(i, direction) {
+  for (const j of groups[i]) turns[j] += direction;
 }
 
-// Scrambling with real taps guarantees the puzzle is still solvable.
+// Replaying real taps keeps the scramble inside the group the taps generate, so
+// every puzzle is solvable. Randomising each tile independently would not be.
 function scramble(count) {
-  for (var k = 0; k < count; k++) tap(Math.floor(Math.random() * cells.length));
+  for (let k = 0; k < count; k++) turn(Math.floor(Math.random() * cells.length), 1);
 }
 
-/* ------------------------------- display -------------------------------- */
+/* ===================== structural self-test ===================== */
 
-// A chevron whose apex points at the tile's top vertex.
-var ARROW = '<svg viewBox="-10 -10 20 20" aria-hidden="true"><path d="M-5.5 3 L0 -3.6 L5.5 3"/></svg>';
+// The board's shape is easy to get subtly wrong and hard to eyeball, so assert it:
+// 19 interior tiles turn 7 at once, 12 edge tiles turn 5, 6 corner tiles turn 4.
+(function selfTest() {
+  const sizes = {};
+  for (const g of groups) sizes[g.length] = (sizes[g.length] || 0) + 1;
+  const symmetric = groups.every((g, i) => g.every(j => groups[j].includes(i)));
+  const pass = cells.length === 37 && symmetric &&
+               sizes[7] === 19 && sizes[5] === 12 && sizes[4] === 6;
+  console[pass ? 'log' : 'error'](
+    '[arrow-puzzle] self-test ' + (pass ? 'PASS' : 'FAIL') +
+    ': ' + cells.length + ' tiles, group sizes ' + JSON.stringify(sizes) +
+    ', adjacency ' + (symmetric ? 'symmetric' : 'ASYMMETRIC'));
+})();
+
+/* ===================== display ===================== */
+
+// Hex of size 97 inside a viewBox sized for 100, so the stroke clears the clip-path
+// and leaves a hairline seam. The chevron's apex points at the tile's top edge.
+const TILE_SVG =
+  '<svg viewBox="-100 -86.603 200 173.205" aria-hidden="true">' +
+  '<polygon class="cell" points="97,0 48.5,-84.004 -48.5,-84.004 -97,0 -48.5,84.004 48.5,84.004"/>' +
+  '<path class="arrow" d="M-38 17 L0 -17 L38 17"/></svg>';
+
+const HEADINGS = ['up', 'upper right', 'lower right', 'down', 'lower left', 'upper left'];
 
 // Flat-top hex packing: columns sit sqrt(3)/2 of a pitch apart and step half a pitch down.
-function offsetX(c) { return Math.sqrt(3) / 2 * c.q; }
-function offsetY(c) { return c.r + c.q / 2; }
+const offsetX = c => Math.sqrt(3) / 2 * c.q;
+const offsetY = c => c.r + c.q / 2;
 
-scramble(40);
+const board = document.getElementById('board');
+const clockEl = document.getElementById('clock');
+const bestEl = document.getElementById('best');
+const movesEl = document.getElementById('moves');
+const bannerEl = document.getElementById('banner');
+const undoEl = document.getElementById('undo');
 
-var board = document.getElementById('board');
-
-var tiles = cells.map(function (c, i) {
-  var tile = document.createElement('button');
+const tiles = cells.map((c, i) => {
+  const tile = document.createElement('button');
   tile.type = 'button';
   tile.className = 'tile';
   tile.style.setProperty('--x', offsetX(c));
   tile.style.setProperty('--y', offsetY(c));
-  tile.style.setProperty('--turn', turns[i]);   // set before insertion so it does not animate in
-  tile.innerHTML = ARROW;
-  tile.addEventListener('click', function () { tap(i); draw(); });
+  tile.style.setProperty('--dist', distanceOf(c));
+  tile.innerHTML = TILE_SVG;
+  tile.addEventListener('click', () => play(i, 1));
+  // Preview the tiles a tap would turn.
+  tile.addEventListener('pointerenter', () => setWarm(i, true));
+  tile.addEventListener('pointerleave', () => setWarm(i, false));
+  tile.addEventListener('focus', () => setWarm(i, true));
+  tile.addEventListener('blur', () => setWarm(i, false));
   board.append(tile);
   return tile;
 });
 
-function draw() {
-  tiles.forEach(function (tile, i) { tile.style.setProperty('--turn', turns[i]); });
+function setWarm(i, on) {
+  for (const j of groups[i]) tiles[j].classList.toggle('warm', on);
 }
+
+// Stagger the neighbours a beat behind the tapped tile so the turn ripples outward.
+function setRipple(i) {
+  const group = i === null ? [] : groups[i];
+  tiles.forEach((tile, k) => {
+    tile.style.setProperty('--delay', group.indexOf(k) > 0 ? '55ms' : '0ms');
+  });
+}
+
+function draw() {
+  tiles.forEach((tile, i) => {
+    tile.style.setProperty('--turn', turns[i]);
+    const c = cells[i];
+    tile.setAttribute('aria-label',
+      c.q + ',' + c.r + ': arrow ' + HEADINGS[((turns[i] % STEPS) + STEPS) % STEPS]);
+  });
+}
+
+// Repaint with no spin, for scrambles and resets.
+function drawInstantly() {
+  board.classList.add('no-tween');
+  draw();
+  void board.offsetWidth;             // flush the new transforms before tweens come back
+  board.classList.remove('no-tween');
+}
+
+/* ===================== clock ===================== */
+
+let startedAt = null;
+let frame = null;
+
+const pad = (n, width) => String(n).padStart(width, '0');
+const format = ms =>
+  pad(Math.floor(ms / 60000), 2) + ':' + pad(Math.floor(ms / 1000) % 60, 2) + '.' + pad(Math.floor(ms) % 1000, 3);
+
+function readBest() {
+  try {
+    const raw = Number(localStorage.getItem('ei-hex-game.best'));
+    return Number.isFinite(raw) && raw > 0 ? raw : null;
+  } catch (e) { return null; }        // storage blocked in private mode
+}
+
+function showBest() {
+  const best = readBest();
+  bestEl.textContent = best === null ? '–' : format(best);
+}
+
+function runClock() {
+  clockEl.textContent = format(performance.now() - startedAt);
+  frame = requestAnimationFrame(runClock);
+}
+
+function startClock() {
+  if (startedAt !== null) return;
+  startedAt = performance.now();
+  runClock();
+}
+
+function stopClock() {
+  if (startedAt === null) return 0;
+  cancelAnimationFrame(frame);
+  const elapsed = performance.now() - startedAt;
+  startedAt = null;
+  clockEl.textContent = format(elapsed);
+  return elapsed;
+}
+
+function resetClock() {
+  cancelAnimationFrame(frame);
+  startedAt = null;
+  clockEl.textContent = format(0);
+}
+
+/* ===================== turn loop ===================== */
+
+let finished = false;
+
+function play(i, direction) {
+  if (finished) return;
+  startClock();
+  turn(i, direction);
+  if (direction > 0) taps.push(i); else taps.pop();
+  setRipple(i);
+  draw();
+  refresh();
+  if (isSolved()) finish();
+}
+
+function refresh() {
+  movesEl.textContent = taps.length;
+  undoEl.disabled = finished || taps.length === 0;
+}
+
+function finish() {
+  finished = true;
+  const elapsed = stopClock();
+  const best = readBest();
+  if (elapsed > 0 && (best === null || elapsed < best)) {
+    try { localStorage.setItem('ei-hex-game.best', elapsed); } catch (e) { /* private mode */ }
+  }
+  showBest();
+  board.classList.add('solved');
+  bannerEl.classList.add('show');
+  undoEl.disabled = true;
+}
+
+function clearFinish() {
+  finished = false;
+  board.classList.remove('solved');
+  bannerEl.classList.remove('show');
+}
+
+/* ===================== controls ===================== */
+
+undoEl.addEventListener('click', () => {
+  if (taps.length) play(taps[taps.length - 1], -1);
+});
+
+// Reset is a workbench tool, not a win: it hands back a solved board without
+// celebrating it. Turning each tile forward to its next multiple of six gets
+// there in at most five steps instead of unwinding the whole game backwards.
+document.getElementById('reset').addEventListener('click', () => {
+  clearFinish();
+  for (let i = 0; i < turns.length; i++) turns[i] = Math.ceil(turns[i] / STEPS) * STEPS;
+  taps.length = 0;
+  setRipple(null);
+  draw();
+  resetClock();
+  refresh();
+});
+
+document.getElementById('fresh').addEventListener('click', newPuzzle);
+
+function newPuzzle() {
+  clearFinish();
+  for (let i = 0; i < turns.length; i++) turns[i] = 0;
+  scramble(40);
+  for (let i = 0; i < turns.length; i++) turns[i] %= STEPS;   // keep the counts small
+  taps.length = 0;
+  setRipple(null);
+  drawInstantly();
+  resetClock();
+  refresh();
+}
+
+showBest();
+newPuzzle();
 </script>
 
 </body>

--- a/ei-hex-game/index.html
+++ b/ei-hex-game/index.html
@@ -59,15 +59,9 @@
 
   /* The hex is drawn a touch inside the clip so its stroke survives, which also
      leaves the hairline seam between tiles that the screenshots have. */
-  /* Only the arrow needs to turn, but a regular hexagon is unchanged by a sixth
-     of a turn, so spinning the whole SVG costs nothing and keeps the markup flat.
-     pointer-events stay off it so the clip-path above is the only hit area. */
-  .tile svg {
-    display: block; width: 100%; height: 100%; pointer-events: none;
-    transform: rotate(calc(var(--turn) * 60deg));
-    transition: transform .26s var(--ease);
-    transition-delay: var(--delay, 0ms);
-  }
+  /* Two stacked SVGs: a still hexagon and a spinning arrow. pointer-events stay off
+     so the clip-path above is the only hit area. */
+  .tile svg { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
   .cell {
     fill: transparent; stroke: var(--line); stroke-width: 2.5;
     transition: fill .18s ease, stroke .18s ease, stroke-width .18s ease;
@@ -77,21 +71,36 @@
   .tile:focus-visible { outline: none; }
   .tile:focus-visible .cell { stroke: #9fb8d8; stroke-width: 6; }
 
+  /* Only the arrow turns. Spinning the hexagon too looks identical at rest, since a
+     regular hexagon is unchanged by a sixth of a turn, but halfway through the tween
+     it sits at 30 degrees with its corners past the clip-path, so the outline gets
+     sliced along the seams it shares with its neighbours.
+     The rotation goes on a root <svg>, which is the one SVG element that centres its
+     own transform-origin. Rotating the <path> instead needs transform-box, whose
+     reference box starts at user-space 0,0 rather than at the viewBox corner, so
+     50% 50% lands half a tile away and flings the arrow out of the clip. */
+  .spin {
+    transform: rotate(calc(var(--turn) * 60deg));
+    transition: transform .26s var(--ease) var(--delay, 0ms);
+  }
   .arrow {
+    --stroke-delay: 0ms;
     fill: none; stroke: var(--ink); stroke-width: 12;
     stroke-linecap: round; stroke-linejoin: round;
-    transition: stroke .45s ease;
+    transition: stroke .45s ease var(--stroke-delay);
   }
 
   /* Instant repaint for scrambles and resets: no spin from the old state. */
-  #board.no-tween .tile svg { transition: none; }
+  #board.no-tween .spin { transition: none; }
 
   /* ---- solved: a glow rippling out from the centre ---- */
   #board.solved .cell {
     animation: flare 1.5s ease-out both;
     animation-delay: calc(var(--dist) * 130ms);
   }
-  #board.solved .arrow { stroke: var(--gold); transition-delay: calc(var(--dist) * 130ms); }
+  /* Delays the stroke only. Overriding transition-delay here would also delay the
+     turn, which would stall the winning move's own rotation. */
+  #board.solved .arrow { stroke: var(--gold); --stroke-delay: calc(var(--dist) * 130ms); }
   @keyframes flare {
     35% { fill: rgba(242, 200, 121, .34); stroke: var(--gold); stroke-width: 4; }
     100% { fill: rgba(242, 200, 121, .1); stroke: rgba(242, 200, 121, .55); stroke-width: 2.5; }
@@ -114,7 +123,7 @@
   .controls button:disabled { color: #6d6d6d; cursor: default; }
 
   @media (prefers-reduced-motion: reduce) {
-    .tile svg, .arrow { transition-duration: 1ms; }
+    .spin, .arrow { transition-duration: 1ms; }
     #board.solved .cell {
       animation: none; fill: rgba(242, 200, 121, .1); stroke: rgba(242, 200, 121, .55);
     }
@@ -208,10 +217,13 @@ function scramble(count) {
 
 // Hex of size 97 inside a viewBox sized for 100, so the stroke clears the clip-path
 // and leaves a hairline seam. The chevron's apex points at the tile's top edge.
+const VIEW_BOX = 'viewBox="-100 -86.603 200 173.205" aria-hidden="true"';
 const TILE_SVG =
-  '<svg viewBox="-100 -86.603 200 173.205" aria-hidden="true">' +
-  '<polygon class="cell" points="97,0 48.5,-84.004 -48.5,-84.004 -97,0 -48.5,84.004 48.5,84.004"/>' +
-  '<path class="arrow" d="M-38 17 L0 -17 L38 17"/></svg>';
+  '<svg ' + VIEW_BOX + '>' +
+  '<polygon class="cell" points="97,0 48.5,-84.004 -48.5,-84.004 -97,0 -48.5,84.004 48.5,84.004"/></svg>' +
+  // Sat 3 units above the geometric centre: a chevron is bottom-heavy, so its bounding
+  // box being centred reads as low. Units, not pixels, so it scales with the tile.
+  '<svg class="spin" ' + VIEW_BOX + '><path class="arrow" d="M-38 14 L0 -20 L38 14"/></svg>';
 
 const HEADINGS = ['up', 'upper right', 'lower right', 'down', 'lower left', 'upper left'];
 
@@ -282,9 +294,12 @@ const pad = (n, width) => String(n).padStart(width, '0');
 const format = ms =>
   pad(Math.floor(ms / 60000), 2) + ':' + pad(Math.floor(ms / 1000) % 60, 2) + '.' + pad(Math.floor(ms) % 1000, 3);
 
+// Bumped to v2 to abandon records written before undo stopped counting as a win.
+const BEST_KEY = 'ei-hex-game.best.v2';
+
 function readBest() {
   try {
-    const raw = Number(localStorage.getItem('ei-hex-game.best'));
+    const raw = Number(localStorage.getItem(BEST_KEY));
     return Number.isFinite(raw) && raw > 0 ? raw : null;
   } catch (e) { return null; }        // storage blocked in private mode
 }
@@ -323,6 +338,7 @@ function resetClock() {
 /* ===================== turn loop ===================== */
 
 let finished = false;
+let ranked = true;              // false once Reset hands back a board nobody scrambled
 
 function play(i, direction) {
   if (finished) return;
@@ -332,7 +348,9 @@ function play(i, direction) {
   setRipple(i);
   draw();
   refresh();
-  if (isSolved()) finish();
+  // Only a forward move can win. Undoing back into a solved board is not a solve:
+  // after Reset to solved, one tap plus one undo would otherwise claim a victory.
+  if (direction > 0 && isSolved()) finish();
 }
 
 function refresh() {
@@ -344,8 +362,10 @@ function finish() {
   finished = true;
   const elapsed = stopClock();
   const best = readBest();
-  if (elapsed > 0 && (best === null || elapsed < best)) {
-    try { localStorage.setItem('ei-hex-game.best', elapsed); } catch (e) { /* private mode */ }
+  // Only a genuinely scrambled board can set a record. Solving your way back from
+  // Reset to solved still celebrates, but a two-second lap does not become the best.
+  if (ranked && elapsed > 0 && (best === null || elapsed < best)) {
+    try { localStorage.setItem(BEST_KEY, elapsed); } catch (e) { /* private mode */ }
   }
   showBest();
   board.classList.add('solved');
@@ -370,6 +390,7 @@ undoEl.addEventListener('click', () => {
 // there in at most five steps instead of unwinding the whole game backwards.
 document.getElementById('reset').addEventListener('click', () => {
   clearFinish();
+  ranked = false;
   for (let i = 0; i < turns.length; i++) turns[i] = Math.ceil(turns[i] / STEPS) * STEPS;
   taps.length = 0;
   setRipple(null);
@@ -382,6 +403,7 @@ document.getElementById('fresh').addEventListener('click', newPuzzle);
 
 function newPuzzle() {
   clearFinish();
+  ranked = true;
   for (let i = 0; i < turns.length; i++) turns[i] = 0;
   scramble(40);
   for (let i = 0; i < turns.length; i++) turns[i] %= STEPS;   // keep the counts small


### PR DESCRIPTION
- [ ] I, the human author, have fully read and comprehended this code. Until this is checked, please don't waste time reviewing.

Turns the tiles into hexagons that tile edge to edge, then adds the finish that PR #16 deliberately left out: a timer, best time, move count, win detection with a glow that ripples out from the centre, and Undo / Reset to solved / New puzzle.

Undo and Reset exist for the last-two-corners algorithm work, which needs a known start state and a way to step back out of a trial sequence.

## Starting points

- [`ei-hex-game/index.html:56`](https://github.com/vosechu/vosechu.github.io/pull/17/files#diff-586d799d5ef3a08592a672ed1d9a4a871ce7780a2ac4190883f359b74434e5f1R56) — `clip-path` on each tile. Load-bearing, not cosmetic: a flat-top hex is 1.1547 pitches wide by 1 tall, so neighbouring tiles' rectangles overlap at the corners. Without the clip, a tap near a corner turned the wrong group.
- [`ei-hex-game/index.html:73`](https://github.com/vosechu/vosechu.github.io/pull/17/files#diff-586d799d5ef3a08592a672ed1d9a4a871ce7780a2ac4190883f359b74434e5f1R73) — why the arrow spins in its own SVG and the hexagon holds still. Two bugs live in this comment; read it before touching the rotation.
- [`ei-hex-game/index.html:195`](https://github.com/vosechu/vosechu.github.io/pull/17/files#diff-586d799d5ef3a08592a672ed1d9a4a871ce7780a2ac4190883f359b74434e5f1R195) — self-test. Asserts 19 seven-tile groups, 12 five-tile groups, 6 four-tile groups and symmetric adjacency, then logs PASS or FAIL to the console.

## Bugs found and fixed during review

- **The hexagon outline spun with the arrow.** Identical at rest, since a regular hexagon is unchanged by a sixth of a turn, but midway through the tween it sits at 30 degrees with its corners past the clip-path and gets sliced along the seams it shares with its neighbours. Read as a pulse.
- **Rotating the `<path>` with `transform-box: view-box` put the reference box at user-space 0,0, not at the viewBox corner.** So `50% 50%` resolved half a tile away and flung most arrows out of the clip. Only tiles already at zero turns still drew, which is what made it obvious. Rotation now goes on a root `<svg>`, the one SVG element that centres its own `transform-origin`.
- **Undo could win the game.** After Reset to solved, one tap plus one undo returned the board to solved, fired the celebration and wrote a sub-second best time. Only forward moves can win now, and Reset-derived boards are unranked. Best-time key moved to `v2` to abandon the bogus records.
- **`newPuzzle()` didn't restore the ranked flag**, so Reset then New puzzle would have silently stopped recording best times forever.

## Concerns

**The tiles are flat-topped, which contradicts your friend's prompt, and his prompt is the thing that's wrong.** It asks for the big hexagon *and* every tile to point a vertex at the top. A hexagon of hexagons is always turned 30 degrees from its own tiles, so those can't both hold.

The screenshots settle which one gives. Measure the tile centres: columns sit about 97px apart and tiles within a column about 112px apart, a ratio of 0.866, or sqrt(3)/2. That is the flat-top packing exactly (column spacing 1.5s over centre distance sqrt(3)s). Pointy-top hexes at those same centres would overlap, because their packing wants a ratio of 1.1547. So the arrangement in the screenshots admits flat-topped tiles and nothing else, and flat-topped tiles put the arrow on the midpoint of the top edge rather than on a vertex.

Changing "vertex" to "edge" in his prompt makes it consistent. His tile count of 37 is right: `3n² − 3n + 1` at side 4, which also matches the screenshot columns of 4‑5‑6‑7‑6‑5‑4.

**Reset to solved does not trigger the win celebration.** It hands back a solved board with no glow and a cleared clock. Deliberate for algorithm work, but it does mean the board can sit visibly solved while the UI says nothing.

## Test plan

- [x] Honeycomb geometry confirmed visually: 37 flat-top hexes tiling into one pointy-top board, clean seams, tiles centred with the rest of the page
- [x] The vanished-arrow bug was diagnosed from that same screenshot: exactly the tiles at `turn ≡ 0` still drew, which is the signature of a wrong rotation origin rather than a wrong path
- [x] Served from local Jekyll on :4000, `diff -q` confirms byte-identical to source, so no front matter and no Liquid processing
- [x] `clip-path` gating hit testing confirmed against the CSS Masking spec, not assumed: pointer events are not dispatched on clipped-away regions
- [x] Root `<svg>` centring its own transform-origin confirmed against MDN, where every other SVG element defaults to `0 0`
- [x] Group-size invariants derived by hand and encoded in the self-test: corner tiles have 3 neighbours, edge tiles 4, interior 6, giving 19/12/6 and 90 adjacent pairs
- [x] Arrow stays inside the hex at every rotation: furthest point 48.9 units against an inradius of 84
- [x] Brace and paren balance, two `<svg>` elements per tile, no invisible Unicode
- [ ] **Post-fix rendering not confirmed by me.** The Chrome extension timed out on every call this session, so the arrows, tween feel and the undo fix were verified by reading, not by watching. Chuck drove the browser and called ship.
- [ ] Not checked on a real phone. The board is capped at 79.5vw wide and 7 pitches tall, which the arithmetic says fits, but that's arithmetic and not a device.
